### PR TITLE
Replace google-generativeai with google-genai SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ openai==1.98.0
 pytest-asyncio==0.21.0
 sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.0
-google-generativeai>=0.3.2
+google-genai>=1.0.0
 google-api-python-client>=2.100.0


### PR DESCRIPTION
The codebase uses `from google import genai` (google-genai SDK) but requirements.txt listed the old google-generativeai package, causing an ImportError on startup.