### PR TITLE
Add spec source sync #7

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,7 @@ These are bigger bets we're exploring. Community input will shape what gets buil
 - [ ] **Analytics dashboard** — topic trends over time, speaker activity, conference stats, transcript volume growth
 - [ ] **Knowledge graph** — extract entities and relationships from transcripts via LLM. Query: "Show me everything related to OP_VAULT" or "How are these speakers connected?"
 - [ ] **Graph visualization** — interactive entity relationship explorer on the frontend
+- [ ] **BIP/BOLT explainers** — ingest Bitcoin and Lightning specifications, match them to transcript context, and generate audience-specific explanations. See [BIP/BOLT Explainer Pipeline](docs/bip_bolt_explainer_pipeline.md).
 
 ---
 

--- a/app/commands/__init__.py
+++ b/app/commands/__init__.py
@@ -2,3 +2,4 @@ from .curator import commands as curator  # noqa: F401
 from .ingest import commands as ingest  # noqa: F401
 from .media import commands as media  # noqa: F401
 from .server import server  # noqa: F401
+from .specs import commands as specs  # noqa: F401

--- a/app/commands/specs.py
+++ b/app/commands/specs.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+import click
+
+from app.spec_sync import (
+    DEFAULT_SPEC_ALLOWLIST,
+    SpecSyncService,
+)
+
+
+@click.group()
+def specs():
+    """BIP/BOLT specification sync commands."""
+
+
+@specs.command()
+@click.argument("spec_ids", nargs=-1)
+@click.option(
+    "--local-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Read spec files from a local directory instead of GitHub.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Write normalized raw spec JSON records to this directory.",
+)
+def sync(spec_ids, local_dir, output_dir):
+    """Sync BIP/BOLT raw specs.
+
+    With no SPEC_IDS, the MVP allowlist is synced:
+    BIP-32, BIP-174, BIP-340, BIP-341, BIP-342, BOLT-11, and BOLT-12.
+    """
+    service = SpecSyncService()
+
+    if local_dir:
+        raw_specs = service.sync_local_directory(local_dir)
+    else:
+        requested_specs = (
+            [service.parse_spec_ref(value) for value in spec_ids]
+            if spec_ids
+            else DEFAULT_SPEC_ALLOWLIST
+        )
+        unknown_specs = [
+            value
+            for value, spec_ref in zip(spec_ids, requested_specs)
+            if spec_ref is None
+        ]
+        if unknown_specs:
+            raise click.ClickException(
+                f"Could not parse spec id(s): {', '.join(unknown_specs)}"
+            )
+        raw_specs = service.sync_allowlist(requested_specs)
+
+    records = [spec.to_dict() for spec in raw_specs]
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for record in records:
+            filename = f"{record['spec_id'].lower()}.json"
+            (output_dir / filename).write_text(
+                json.dumps(record, indent=2), encoding="utf-8"
+            )
+
+    click.echo(json.dumps(records, indent=2))
+
+
+commands = specs

--- a/app/spec_sync.py
+++ b/app/spec_sync.py
@@ -1,0 +1,280 @@
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import requests
+
+
+SUPPORTED_SPEC_EXTENSIONS = {".md", ".mediawiki", ".rst"}
+
+
+@dataclass(frozen=True)
+class SpecSource:
+    """Canonical source repository for BIP/BOLT specification files."""
+
+    spec_type: str
+    owner: str
+    repo: str
+    branch: str
+    path_template: str
+    source_base_url: str
+
+    @property
+    def repository(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+
+@dataclass(frozen=True)
+class RawSpec:
+    """Normalized raw spec record produced by source sync."""
+
+    spec_id: str
+    spec_type: str
+    number: int
+    raw_text: str
+    source_url: str
+    source_path: str
+    source_repository: str
+    commit_hash: Optional[str]
+    content_hash: str
+    fetched_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "spec_id": self.spec_id,
+            "spec_type": self.spec_type,
+            "number": self.number,
+            "raw_text": self.raw_text,
+            "source_url": self.source_url,
+            "source_path": self.source_path,
+            "source_repository": self.source_repository,
+            "commit_hash": self.commit_hash,
+            "content_hash": self.content_hash,
+            "fetched_at": self.fetched_at,
+        }
+
+
+@dataclass(frozen=True)
+class SpecRef:
+    """A requested specification identifier."""
+
+    spec_type: str
+    number: int
+
+    @property
+    def spec_id(self) -> str:
+        return f"{self.spec_type.upper()}-{self.number}"
+
+
+BIP_SOURCE = SpecSource(
+    spec_type="bip",
+    owner="bitcoin",
+    repo="bips",
+    branch="master",
+    path_template="bip-{number:04d}.mediawiki",
+    source_base_url="https://github.com/bitcoin/bips/blob/{commit}/{path}",
+)
+
+BOLT_SOURCE = SpecSource(
+    spec_type="bolt",
+    owner="lightning",
+    repo="bolts",
+    branch="master",
+    path_template="{number:02d}-{name}.md",
+    source_base_url="https://github.com/lightning/bolts/blob/{commit}/{path}",
+)
+
+
+DEFAULT_SPEC_SOURCES = {
+    "bip": BIP_SOURCE,
+    "bolt": BOLT_SOURCE,
+}
+
+
+DEFAULT_SPEC_ALLOWLIST = (
+    SpecRef("bip", 32),
+    SpecRef("bip", 174),
+    SpecRef("bip", 340),
+    SpecRef("bip", 341),
+    SpecRef("bip", 342),
+    SpecRef("bolt", 11),
+    SpecRef("bolt", 12),
+)
+
+
+class SpecSyncError(Exception):
+    """Raised when a specification cannot be synced."""
+
+
+class SpecSyncService:
+    """Fetch BIP/BOLT specification files into normalized raw records."""
+
+    def __init__(
+        self,
+        sources: Optional[dict[str, SpecSource]] = None,
+        session: Optional[requests.Session] = None,
+    ):
+        self.sources = sources or DEFAULT_SPEC_SOURCES
+        self.session = session or requests.Session()
+
+    def sync_allowlist(
+        self, specs: Iterable[SpecRef] = DEFAULT_SPEC_ALLOWLIST
+    ) -> list[RawSpec]:
+        return [self.sync_spec(spec) for spec in specs]
+
+    def sync_spec(self, spec: SpecRef | str) -> RawSpec:
+        spec_ref = self.parse_spec_ref(spec) if isinstance(spec, str) else spec
+        if spec_ref is None:
+            raise SpecSyncError(f"Could not parse spec id: {spec}")
+        source = self._get_source(spec_ref.spec_type)
+        commit_hash = self.get_branch_commit(source)
+        source_path = self.resolve_source_path(source, spec_ref.number)
+        raw_text = self.fetch_raw_text(source, source_path, commit_hash)
+
+        return self._build_raw_spec(
+            spec_ref=spec_ref,
+            source=source,
+            raw_text=raw_text,
+            source_path=source_path,
+            commit_hash=commit_hash,
+        )
+
+    def sync_local_directory(self, directory: str | Path) -> list[RawSpec]:
+        root = Path(directory)
+        if not root.exists():
+            raise SpecSyncError(f"Spec directory does not exist: {root}")
+
+        specs = []
+        for path in sorted(root.rglob("*")):
+            if path.suffix.lower() not in SUPPORTED_SPEC_EXTENSIONS:
+                continue
+            spec_ref = self.parse_spec_ref(path.name)
+            if spec_ref is None:
+                continue
+            raw_text = path.read_text(encoding="utf-8")
+            specs.append(self._build_local_raw_spec(spec_ref, path, raw_text))
+        return specs
+
+    def get_branch_commit(self, source: SpecSource) -> str:
+        url = (
+            f"https://api.github.com/repos/{source.owner}/{source.repo}"
+            f"/commits/{source.branch}"
+        )
+        response = self.session.get(url, timeout=30)
+        response.raise_for_status()
+        return response.json()["sha"]
+
+    def resolve_source_path(self, source: SpecSource, number: int) -> str:
+        if source.spec_type == "bolt":
+            return self._resolve_bolt_path(source, number)
+        return source.path_template.format(number=number)
+
+    def fetch_raw_text(
+        self, source: SpecSource, source_path: str, commit_hash: str
+    ) -> str:
+        url = (
+            f"https://raw.githubusercontent.com/{source.owner}/{source.repo}"
+            f"/{commit_hash}/{source_path}"
+        )
+        response = self.session.get(url, timeout=30)
+        response.raise_for_status()
+        return response.text
+
+    @staticmethod
+    def parse_spec_ref(value: str) -> Optional[SpecRef]:
+        normalized = value.lower()
+
+        bip_match = re.search(r"\bbip[-_\s]?0*(\d{1,4})\b", normalized)
+        if bip_match:
+            return SpecRef("bip", int(bip_match.group(1)))
+
+        bolt_match = re.search(r"\bbolt[-_\s]?0*(\d{1,3})\b", normalized)
+        if bolt_match:
+            return SpecRef("bolt", int(bolt_match.group(1)))
+
+        bip_file_match = re.search(r"\bbip-0*(\d{1,4})\.", normalized)
+        if bip_file_match:
+            return SpecRef("bip", int(bip_file_match.group(1)))
+
+        bolt_file_match = re.search(r"\b0*(\d{1,3})-[a-z0-9_-]+\.", normalized)
+        if bolt_file_match:
+            return SpecRef("bolt", int(bolt_file_match.group(1)))
+
+        return None
+
+    def _resolve_bolt_path(self, source: SpecSource, number: int) -> str:
+        tree_url = (
+            f"https://api.github.com/repos/{source.owner}/{source.repo}"
+            f"/git/trees/{source.branch}"
+        )
+        response = self.session.get(tree_url, timeout=30)
+        response.raise_for_status()
+
+        prefix = f"{number:02d}-"
+        for item in response.json().get("tree", []):
+            path = item.get("path", "")
+            if path.startswith(prefix) and path.endswith(".md"):
+                return path
+
+        raise SpecSyncError(
+            f"Could not find BOLT-{number} in {source.repository}"
+        )
+
+    def _build_raw_spec(
+        self,
+        spec_ref: SpecRef,
+        source: SpecSource,
+        raw_text: str,
+        source_path: str,
+        commit_hash: Optional[str],
+    ) -> RawSpec:
+        resolved_commit = commit_hash or "local"
+        source_url = source.source_base_url.format(
+            commit=resolved_commit,
+            path=source_path,
+        )
+        return RawSpec(
+            spec_id=spec_ref.spec_id,
+            spec_type=spec_ref.spec_type,
+            number=spec_ref.number,
+            raw_text=raw_text,
+            source_url=source_url,
+            source_path=source_path,
+            source_repository=source.repository,
+            commit_hash=commit_hash,
+            content_hash=self._content_hash(raw_text),
+            fetched_at=self._utc_now(),
+        )
+
+    def _build_local_raw_spec(
+        self, spec_ref: SpecRef, path: Path, raw_text: str
+    ) -> RawSpec:
+        return RawSpec(
+            spec_id=spec_ref.spec_id,
+            spec_type=spec_ref.spec_type,
+            number=spec_ref.number,
+            raw_text=raw_text,
+            source_url=path.resolve().as_uri(),
+            source_path=str(path),
+            source_repository="local",
+            commit_hash=None,
+            content_hash=self._content_hash(raw_text),
+            fetched_at=self._utc_now(),
+        )
+
+    def _get_source(self, spec_type: str) -> SpecSource:
+        try:
+            return self.sources[spec_type]
+        except KeyError:
+            raise SpecSyncError(f"Unsupported spec type: {spec_type}")
+
+    @staticmethod
+    def _content_hash(raw_text: str) -> str:
+        return hashlib.sha256(raw_text.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.now(timezone.utc).isoformat()

--- a/docs/bip_bolt_explainer_pipeline.md
+++ b/docs/bip_bolt_explainer_pipeline.md
@@ -1,0 +1,230 @@
+# BIP/BOLT Explainer Pipeline
+
+This document proposes an initial pipeline for issue #7: LLM-based explainers for
+BIPs and BOLTs. The goal is to connect canonical Bitcoin and Lightning
+specifications with BitScribe transcript context, then generate explanations for
+different audiences.
+
+## Goals
+
+- Sync BIPs from `bitcoin/bips` and BOLTs from `lightning/bolts`.
+- Parse specification markdown into structured metadata and chunks.
+- Detect BIP/BOLT references in existing transcripts.
+- Use transcript context when available to improve explanations.
+- Generate beginner, developer, and researcher explanations.
+- Cache generated output by source version, audience, prompt version, and model.
+
+## Pipeline
+
+```text
+BIP/BOLT GitHub repos
+        |
+        v
+[Spec sync]
+        |
+        v
+[Raw spec storage]
+        |
+        v
+[Spec parser and chunker]
+        |
+        v
+[Parsed specs, chunks, aliases]
+        |
+        +-----------------------------+
+        |                             |
+        v                             v
+[Transcript reference matcher]   [Vector index]
+        |                             |
+        v                             v
+[Transcript/spec links]       [Retrievable context]
+        |                             |
+        +-------------+---------------+
+                      |
+                      v
+            [Explanation strategy]
+                      |
+        +-------------+--------------+
+        |                            |
+        v                            v
+[Single-shot generation]       [RAG generation]
+        |                            |
+        +-------------+--------------+
+                      |
+                      v
+              [Audience output]
+                      |
+                      v
+          [Explanation cache and API]
+```
+
+## Components
+
+### Spec Sync
+
+Fetch markdown files from the upstream specification repositories and track the
+source version used for every generated explanation.
+
+Initial metadata to store:
+
+- spec type: `bip` or `bolt`
+- spec number
+- title
+- source repository
+- source path
+- source commit
+- content hash
+- raw markdown
+- synced timestamp
+
+### Spec Parser
+
+Convert raw markdown into structured sections. The parser should prefer markdown
+heading boundaries before falling back to character or token windows.
+
+Useful BIP sections include:
+
+- abstract
+- motivation
+- specification
+- rationale
+- backwards compatibility
+- reference implementation
+- test vectors
+
+Useful BOLT sections include:
+
+- overview
+- message formats
+- requirements
+- feature bits
+- protocol flow
+- compatibility notes
+
+### Transcript Reference Matcher
+
+Detect when existing transcripts mention BIPs or BOLTs.
+
+The first implementation can combine regex matching with a small curated alias
+map.
+
+Example regex patterns:
+
+```text
+\bBIP[-\s]?(\d{1,4})\b
+\bBOLT[-\s]?(\d{1,3})\b
+\bBLIP[-\s]?(\d{1,3})\b
+```
+
+Example aliases:
+
+```text
+Schnorr -> BIP-340
+Taproot -> BIP-341
+Tapscript -> BIP-342
+PSBT -> BIP-174
+HD wallets -> BIP-32
+Lightning invoices -> BOLT-11
+Offers -> BOLT-12
+```
+
+Each match should eventually include a confidence score and nearby transcript
+context.
+
+### Explanation Strategy
+
+The explainer should choose between two generation paths.
+
+Single-shot generation is used when only the spec text is available. The LLM
+receives the parsed spec and produces a structured explanation for the requested
+audience.
+
+RAG generation is used when linked transcript context exists. The LLM receives
+the relevant spec chunks plus retrieved transcript chunks. The spec remains the
+source of truth, while transcripts provide explanatory and historical context.
+
+## Audience Levels
+
+### Beginner
+
+Explain the motivation and core idea in plain language. Avoid unnecessary jargon
+and include a glossary for unavoidable technical terms.
+
+### Developer
+
+Focus on implementation details, validation rules, data structures, edge cases,
+compatibility concerns, and related specifications.
+
+### Researcher
+
+Focus on tradeoffs, assumptions, design alternatives, security considerations,
+and historical context.
+
+## Suggested Output Shape
+
+Generated explanations should be stored as structured data so the frontend can
+render each section independently.
+
+```json
+{
+  "spec": "BIP-340",
+  "title": "Schnorr Signatures for secp256k1",
+  "audience": "developer",
+  "summary": "...",
+  "motivation": "...",
+  "how_it_works": "...",
+  "key_concepts": [
+    {
+      "term": "Schnorr signature",
+      "definition": "..."
+    }
+  ],
+  "technical_details": "...",
+  "implications": "...",
+  "related_specs": ["BIP-341", "BIP-342"],
+  "linked_transcripts": [
+    {
+      "transcript_id": "...",
+      "title": "...",
+      "matched_text": "Taproot and Schnorr",
+      "confidence": 0.92
+    }
+  ],
+  "qa": [
+    {
+      "question": "Does this change old Bitcoin addresses?",
+      "answer": "..."
+    }
+  ]
+}
+```
+
+## MVP Scope
+
+Start with a small set of high-value specs:
+
+- BIP-32: hierarchical deterministic wallets
+- BIP-174: partially signed Bitcoin transactions
+- BIP-340: Schnorr signatures
+- BIP-341: Taproot
+- BIP-342: Tapscript
+- BOLT-11: Lightning invoices
+- BOLT-12: offers
+
+## First Implementation Step
+
+The smallest useful implementation can add:
+
+- a spec sync service skeleton
+- a parser interface
+- a transcript reference matcher using regex and aliases
+- an explainer service interface
+- cached output schema
+
+LLM generation and full vector search can be added after the data model and
+matching flow are reviewed.
+
+## Guiding Principle
+
+The specification text is the source of truth. Transcript context should improve
+understanding, but it should not be treated as normative protocol behavior.

--- a/docs/bip_bolt_explainer_pipeline.md
+++ b/docs/bip_bolt_explainer_pipeline.md
@@ -224,6 +224,38 @@ The smallest useful implementation can add:
 LLM generation and full vector search can be added after the data model and
 matching flow are reviewed.
 
+### Step 1: Spec Source Sync
+
+The initial sync implementation fetches or reads BIP/BOLT files and returns
+normalized raw spec records. Transcript matching remains out of scope for this
+phase.
+
+CLI examples:
+
+```bash
+# Sync the MVP allowlist from canonical GitHub repos.
+tstbtc specs sync --output-dir data/raw_specs
+
+# Sync specific specs from canonical GitHub repos.
+tstbtc specs sync BIP-341 BOLT-11 --output-dir data/raw_specs
+
+# Read local spec files instead of fetching from GitHub.
+tstbtc specs sync --local-dir ./specs --output-dir data/raw_specs
+```
+
+Each raw record includes:
+
+- `spec_id`
+- `spec_type`
+- `number`
+- `raw_text`
+- `source_url`
+- `source_path`
+- `source_repository`
+- `commit_hash`
+- `content_hash`
+- `fetched_at`
+
 ## Guiding Principle
 
 The specification text is the source of truth. Transcript context should improve

--- a/test/test_spec_sync.py
+++ b/test/test_spec_sync.py
@@ -1,0 +1,140 @@
+import hashlib
+
+import pytest
+
+from app.spec_sync import (
+    DEFAULT_SPEC_ALLOWLIST,
+    RawSpec,
+    SpecRef,
+    SpecSyncError,
+    SpecSyncService,
+)
+
+
+class FakeResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data or {}
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self):
+        self.urls = []
+
+    def get(self, url, timeout):
+        self.urls.append((url, timeout))
+        if "/commits/master" in url:
+            return FakeResponse({"sha": "abc123"})
+        if "/git/trees/master" in url:
+            return FakeResponse(
+                {
+                    "tree": [
+                        {"path": "01-messaging.md"},
+                        {"path": "11-payment-encoding.md"},
+                        {"path": "12-offer-encoding.md"},
+                    ]
+                }
+            )
+        if "raw.githubusercontent.com" in url:
+            return FakeResponse(text="Specification body")
+        raise AssertionError(f"Unexpected URL: {url}")
+
+
+def test_default_allowlist_contains_initial_mvp_specs():
+    assert [spec.spec_id for spec in DEFAULT_SPEC_ALLOWLIST] == [
+        "BIP-32",
+        "BIP-174",
+        "BIP-340",
+        "BIP-341",
+        "BIP-342",
+        "BOLT-11",
+        "BOLT-12",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("BIP-341", SpecRef("bip", 341)),
+        ("bip0340", SpecRef("bip", 340)),
+        ("bip-0174.mediawiki", SpecRef("bip", 174)),
+        ("BOLT 12", SpecRef("bolt", 12)),
+        ("11-payment-encoding.md", SpecRef("bolt", 11)),
+    ],
+)
+def test_parse_spec_ref(value, expected):
+    assert SpecSyncService.parse_spec_ref(value) == expected
+
+
+def test_sync_spec_fetches_and_normalizes_bip():
+    service = SpecSyncService(session=FakeSession())
+
+    spec = service.sync_spec("BIP-341")
+
+    assert isinstance(spec, RawSpec)
+    assert spec.spec_id == "BIP-341"
+    assert spec.spec_type == "bip"
+    assert spec.number == 341
+    assert spec.raw_text == "Specification body"
+    assert spec.source_path == "bip-0341.mediawiki"
+    assert spec.source_repository == "bitcoin/bips"
+    assert spec.commit_hash == "abc123"
+    assert spec.content_hash == hashlib.sha256(
+        b"Specification body"
+    ).hexdigest()
+    assert spec.source_url == (
+        "https://github.com/bitcoin/bips/blob/abc123/bip-0341.mediawiki"
+    )
+
+
+def test_sync_spec_discovers_bolt_path_from_repo_tree():
+    service = SpecSyncService(session=FakeSession())
+
+    spec = service.sync_spec("BOLT-11")
+
+    assert spec.spec_id == "BOLT-11"
+    assert spec.source_path == "11-payment-encoding.md"
+    assert spec.source_repository == "lightning/bolts"
+    assert spec.source_url == (
+        "https://github.com/lightning/bolts/blob/abc123/"
+        "11-payment-encoding.md"
+    )
+
+
+def test_sync_spec_rejects_unknown_spec_id():
+    service = SpecSyncService(session=FakeSession())
+
+    with pytest.raises(SpecSyncError):
+        service.sync_spec("not-a-spec")
+
+
+def test_sync_local_directory_discovers_supported_specs(tmp_path):
+    (tmp_path / "bip-0340.mediawiki").write_text(
+        "BIP 340 body", encoding="utf-8"
+    )
+    (tmp_path / "12-offer-encoding.md").write_text(
+        "BOLT 12 body", encoding="utf-8"
+    )
+    (tmp_path / "notes.txt").write_text("ignored", encoding="utf-8")
+
+    specs = SpecSyncService().sync_local_directory(tmp_path)
+
+    assert [spec.spec_id for spec in specs] == ["BOLT-12", "BIP-340"]
+    assert {spec.source_repository for spec in specs} == {"local"}
+    assert all(spec.commit_hash is None for spec in specs)
+    assert all(spec.source_url.startswith("file:///") for spec in specs)
+
+
+def test_sync_local_directory_rejects_missing_path(tmp_path):
+    missing = tmp_path / "missing"
+
+    with pytest.raises(SpecSyncError):
+        SpecSyncService().sync_local_directory(missing)

--- a/transcriber.py
+++ b/transcriber.py
@@ -562,6 +562,7 @@ cli.add_command(commands.media)
 cli.add_command(commands.curator)
 cli.add_command(commands.server)
 cli.add_command(commands.ingest)
+cli.add_command(commands.specs)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Sources:

- bitcoin/bips
- lightning/bolts
- Later: local .md, .mediawiki, .rst files

Output object:

`{
  "spec_id": "BIP-341",
  "spec_type": "bip",
  "number": 341,
  "title": "Taproot",
  "raw_text": "...",
  "source_url": "...",
  "source_path": "...",
  "commit_hash": "...",
  "content_hash": "...",
  "fetched_at": "..."
}`