### PR TITLE
Centralise LLM Provider Logic

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -109,10 +109,6 @@ class Settings:
         )
 
     @property
-    def LLM_PROVIDER(self):
-        return os.getenv("LLM_PROVIDER", "openai")
-
-    @property
     def OPENAI_API_KEY(self):
         return self._get_env_variable("OPENAI_API_KEY")
 

--- a/app/data_writer.py
+++ b/app/data_writer.py
@@ -36,7 +36,7 @@ class DataWriter:
             type="json",
             include_timestamp=include_timestamp,
         )
-        with open(output_file, "w") as json_file:
+        with open(output_file, "w", encoding="utf-8") as json_file:
             json.dump(data, json_file, indent=4)
         return output_file
 

--- a/app/exporters.py
+++ b/app/exporters.py
@@ -118,10 +118,10 @@ class TranscriptExporter(ABC):
         try:
             # Handle different content types based on file extension
             if file_path.endswith(".json") and isinstance(content, dict):
-                with open(file_path, "w") as f:
+                with open(file_path, "w", encoding="utf-8") as f:
                     json.dump(content, f, indent=4)
             else:
-                with open(file_path, "w") as f:
+                with open(file_path, "w", encoding="utf-8") as f:
                     f.write(content)
 
             return os.path.abspath(file_path)

--- a/app/github_api_handler.py
+++ b/app/github_api_handler.py
@@ -192,7 +192,7 @@ class GitHubAPIHandler:
                 commit_files = []
                 for file_path in metadata_files:
                     if file_path:
-                        with open(file_path) as file:
+                        with open(file_path, encoding="utf-8") as file:
                             content = file.read()
                         commit_files.append(
                             {

--- a/app/services/content_classifier.py
+++ b/app/services/content_classifier.py
@@ -1,14 +1,11 @@
 import json
 import re
-import time
 from datetime import datetime, timezone
-
-from google import genai
-from google.genai.types import GenerateContentConfig
 
 from app.config import settings
 from app.logging import get_logger
 from app.services.database_service import get_database_service
+from app.services.llm_service import call_llm
 
 
 logger = get_logger()
@@ -20,7 +17,7 @@ class ContentClassifier:
     def __init__(self):
         self._db = get_database_service()
         self.model = settings.config.get(
-            "classification_model", "gemini-3-flash-preview"
+            "classification_model", "gemini:gemini-3-flash-preview"
         )
         self.confidence_threshold = float(
             settings.config.get("classification_confidence_threshold", "0.7")
@@ -217,24 +214,8 @@ class ContentClassifier:
 
     def _call_llm(self, prompt: str) -> dict:
         """Call the LLM and parse its classification response."""
-        client = genai.Client(api_key=settings.GOOGLE_API_KEY)
-        config = GenerateContentConfig(max_output_tokens=1024)
-
-        for attempt in range(4):
-            try:
-                response = client.models.generate_content(
-                    model=self.model,
-                    contents=prompt,
-                    config=config,
-                )
-                return self._parse_response(response.text)
-            except Exception as e:
-                if ("503" in str(e) or "429" in str(e)) and attempt < 3:
-                    wait = 2 ** attempt * 5
-                    logger.warning(f"Gemini rate limited (attempt {attempt+1}), waiting {wait}s...")
-                    time.sleep(wait)
-                else:
-                    raise
+        response_text = call_llm(self.model, prompt, max_tokens=1024)
+        return self._parse_response(response_text)
 
     @staticmethod
     def _parse_response(response_text: str) -> dict:

--- a/app/services/correction.py
+++ b/app/services/correction.py
@@ -1,12 +1,6 @@
-import time
-
-import openai
-from google import genai
-from google.genai.types import GenerateContentConfig
-
-from app.config import settings
 from app.logging import get_logger
 from app.services.global_tag_manager import GlobalTagManager
+from app.services.llm_service import call_llm
 from app.transcript import Transcript
 
 
@@ -17,19 +11,9 @@ MIN_LENGTH_RATIO = 0.7
 
 
 class CorrectionService:
-    def __init__(self, provider="openai", model="gpt-4o"):
-        self.provider = provider
-        self.model = model
+    def __init__(self, model_string="openai:gpt-4o"):
+        self.model_string = model_string
         self.tag_manager = GlobalTagManager()
-        if self.provider == "openai":
-            self.client = openai
-            self.client.api_key = settings.OPENAI_API_KEY
-        elif self.provider == "google":
-            self._client = genai.Client(api_key=settings.GOOGLE_API_KEY)
-            if self.model == "gpt-4o":  # Default overwrite for google
-                self.model = "gemini-3-flash-preview"
-        else:
-            raise ValueError(f"Unsupported LLM provider: {provider}")
 
     def _split_into_chunks(
         self, text: str, max_size: int = MAX_CHUNK_SIZE
@@ -59,7 +43,7 @@ class CorrectionService:
 
     def process(self, transcript: Transcript, **kwargs):
         logger.info(
-            f"Correcting transcript with {self.provider} (model: {self.model})..."
+            f"Correcting transcript with model: {self.model_string}..."
         )
         keywords = kwargs.get("keywords", [])
 
@@ -90,15 +74,7 @@ class CorrectionService:
             )
 
             try:
-                if self.provider == "openai":
-                    response = self.client.chat.completions.create(
-                        model=self.model,
-                        messages=[{"role": "user", "content": prompt}],
-                        timeout=300,  # 5 minute timeout
-                    )
-                    corrected_text = response.choices[0].message.content
-                elif self.provider == "google":
-                    corrected_text = self._call_with_retry(prompt, max_tokens=16384)
+                corrected_text = call_llm(self.model_string, prompt, max_tokens=16384)
 
                 # Validate output length — reject truncated responses
                 if len(corrected_text) < len(chunk) * MIN_LENGTH_RATIO:
@@ -124,34 +100,13 @@ class CorrectionService:
                     f"[CORRECTION FALLBACK] Using original text for chunk {i}/{num_chunks}"
                 )
 
-            # Rate limit between chunks to avoid 429/503
-            if self.provider == "google" and i < num_chunks:
-                time.sleep(2)
-
         # Combine all corrected chunks
         transcript.outputs["corrected_text"] = "\n\n".join(corrected_chunks)
         logger.info(
             f"Correction complete. Total corrected length: {len(transcript.outputs['corrected_text'])} chars"
         )
 
-    def _call_with_retry(self, prompt, max_tokens=8192, max_retries=4):
-        """Call Gemini with exponential backoff on 503/429 errors."""
-        config = GenerateContentConfig(max_output_tokens=max_tokens)
-        for attempt in range(max_retries):
-            try:
-                response = self._client.models.generate_content(
-                    model=self.model,
-                    contents=prompt,
-                    config=config,
-                )
-                return response.text
-            except Exception as e:
-                if ("503" in str(e) or "429" in str(e)) and attempt < max_retries - 1:
-                    wait = 2 ** attempt * 5  # 5, 10, 20, 40 seconds
-                    logger.warning(f"Gemini rate limited (attempt {attempt+1}), waiting {wait}s...")
-                    time.sleep(wait)
-                else:
-                    raise
+
 
     def _build_enhanced_prompt(self, text, keywords, metadata, global_context):
         prompt = (

--- a/app/services/deepgram.py
+++ b/app/services/deepgram.py
@@ -84,14 +84,14 @@ class Deepgram:
             # Add deepgram output file path to transcript's metadata file
             if transcript.metadata_file is not None:
                 # Read existing content of the metadata file
-                with open(transcript.metadata_file) as file:
+                with open(transcript.metadata_file, encoding="utf-8") as file:
                     data = json.load(file)
                 # Add deepgram output
                 data["deepgram_output"] = os.path.basename(
                     transcription_service_output_file
                 )
                 # Write the updated dictionary back to the JSON file
-                with open(transcript.metadata_file, "w") as file:
+                with open(transcript.metadata_file, "w", encoding="utf-8") as file:
                     json.dump(data, file, indent=4)
 
             return transcription_service_output_file
@@ -105,7 +105,8 @@ class Deepgram:
         if not transcript.outputs["transcription_service_output_file"]:
             raise Exception("No 'deepgram_output' found in JSON")
         with open(
-            transcript.outputs["transcription_service_output_file"]
+            transcript.outputs["transcription_service_output_file"],
+            encoding="utf-8",
         ) as outfile:
             transcription_service_output = json.load(outfile)
 
@@ -649,7 +650,8 @@ class Deepgram:
             if not transcript.outputs["transcription_service_output_file"]:
                 raise Exception("No 'deepgram_output' found in JSON")
             with open(
-                transcript.outputs["transcription_service_output_file"]
+                transcript.outputs["transcription_service_output_file"],
+                encoding="utf-8",
             ) as outfile:
                 transcription_service_output = json.load(outfile)
 

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,0 +1,62 @@
+import time
+import openai
+from google import genai
+from google.genai.types import GenerateContentConfig
+
+from app.config import settings
+from app.logging import get_logger
+
+logger = get_logger()
+
+def parse_model_string(model_string: str, default_provider: str = "openai") -> tuple[str, str]:
+    """Parse a model string like 'openai:gpt-4o' or just 'gpt-4o' into provider and model."""
+    if ":" in model_string:
+        provider, model = model_string.split(":", 1)
+        return provider.lower(), model
+    return default_provider, model_string
+
+def call_llm(model_string: str, prompt: str, max_tokens: int = 8192, default_provider: str = "openai") -> str:
+    """Central point to call different LLM providers."""
+    provider, model = parse_model_string(model_string, default_provider)
+    if provider == "openai":
+        return call_openai(model, prompt, max_tokens)
+    elif provider in ["google", "gemini"]:
+        return call_gemini(model, prompt, max_tokens)
+    else:
+        raise ValueError(f"Unsupported LLM provider: {provider}")
+
+def call_openai(model: str, prompt: str, max_tokens: int = 8192) -> str:
+    """Call OpenAI API."""
+    try:
+        openai.api_key = settings.OPENAI_API_KEY
+        response = openai.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+            timeout=300,
+        )
+        return response.choices[0].message.content
+    except Exception as e:
+        logger.error(f"OpenAI API error: {e}")
+        raise
+
+def call_gemini(model: str, prompt: str, max_tokens: int = 8192, max_retries: int = 4) -> str:
+    """Call Gemini API with exponential backoff on rate limits."""
+    client = genai.Client(api_key=settings.GOOGLE_API_KEY)
+    config = GenerateContentConfig(max_output_tokens=max_tokens)
+    for attempt in range(max_retries):
+        try:
+            response = client.models.generate_content(
+                model=model,
+                contents=prompt,
+                config=config,
+            )
+            return response.text
+        except Exception as e:
+            if ("503" in str(e) or "429" in str(e)) and attempt < max_retries - 1:
+                wait = 2 ** attempt * 5
+                logger.warning(f"Gemini rate limited (attempt {attempt+1}), waiting {wait}s...")
+                time.sleep(wait)
+            else:
+                logger.error(f"Gemini API error: {e}")
+                raise

--- a/app/services/metadata_extractor.py
+++ b/app/services/metadata_extractor.py
@@ -1,11 +1,7 @@
 import json
-import time
 
-from google import genai
-from google.genai.types import GenerateContentConfig
-
-from app.config import settings
 from app.logging import get_logger
+from app.services.llm_service import call_llm
 from app.transcript import Transcript
 
 
@@ -21,9 +17,8 @@ class MetadataExtractorService:
     correction and summarization, so extracted metadata enriches those steps.
     """
 
-    def __init__(self, model="gemini-3-flash-preview"):
-        self.model = model
-        self._client = genai.Client(api_key=settings.GOOGLE_API_KEY)
+    def __init__(self, model_string="gemini:gemini-3-flash-preview"):
+        self.model_string = model_string
 
     def process(self, transcript: Transcript, **kwargs):
         """
@@ -55,7 +50,7 @@ class MetadataExtractorService:
         prompt = self._build_prompt(title, description, channel_name, tags)
 
         try:
-            response = self._call_with_retry(prompt, max_tokens=1024)
+            response = call_llm(self.model_string, prompt, max_tokens=1024)
             extracted = self._parse_response(response)
 
             # Update speakers only if they weren't manually provided
@@ -85,24 +80,7 @@ class MetadataExtractorService:
                 f"Existing metadata preserved."
             )
 
-    def _call_with_retry(self, prompt, max_tokens=1024, max_retries=4):
-        """Call Gemini with exponential backoff on 503/429 errors."""
-        config = GenerateContentConfig(max_output_tokens=max_tokens)
-        for attempt in range(max_retries):
-            try:
-                response = self._client.models.generate_content(
-                    model=self.model,
-                    contents=prompt,
-                    config=config,
-                )
-                return response.text
-            except Exception as e:
-                if ("503" in str(e) or "429" in str(e)) and attempt < max_retries - 1:
-                    wait = 2 ** attempt * 5  # 5, 10, 20, 40 seconds
-                    logger.warning(f"Gemini rate limited (attempt {attempt+1}), waiting {wait}s...")
-                    time.sleep(wait)
-                else:
-                    raise
+
 
     def _build_prompt(self, title, description, channel_name, tags):
         """Build the extraction prompt for the LLM."""

--- a/app/services/smallestai.py
+++ b/app/services/smallestai.py
@@ -106,10 +106,10 @@ class SmallestAI:
             logger.info(f"(smallestai) Model output stored at: {output_file}")
 
             if transcript.metadata_file is not None:
-                with open(transcript.metadata_file) as file:
+                with open(transcript.metadata_file, encoding="utf-8") as file:
                     data = json.load(file)
                 data["smallestai_output"] = os.path.basename(output_file)
-                with open(transcript.metadata_file, "w") as file:
+                with open(transcript.metadata_file, "w", encoding="utf-8") as file:
                     json.dump(data, file, indent=4)
 
             return output_file
@@ -302,7 +302,7 @@ class SmallestAI:
         )
         logger.info(f"(smallestai) Writing SRT to {output_file}...")
 
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             for i, utt in enumerate(utterances, 1):
                 f.write(f"{i}\n")
                 f.write(
@@ -319,7 +319,8 @@ class SmallestAI:
                 raise Exception("No 'smallestai_output' found")
 
             with open(
-                transcript.outputs["transcription_service_output_file"]
+                transcript.outputs["transcription_service_output_file"],
+                encoding="utf-8",
             ) as f:
                 transcription_service_output = json.load(f)
 
@@ -422,10 +423,10 @@ class SmallestAI:
         )
 
         if transcript.metadata_file is not None:
-            with open(transcript.metadata_file) as file:
+            with open(transcript.metadata_file, encoding="utf-8") as file:
                 data = json.load(file)
             data["smallestai_chunks"] = smallestai_chunks
-            with open(transcript.metadata_file, "w") as file:
+            with open(transcript.metadata_file, "w", encoding="utf-8") as file:
                 json.dump(data, file, indent=4)
 
         return transcription_service_output

--- a/app/services/summarizer.py
+++ b/app/services/summarizer.py
@@ -1,11 +1,5 @@
-import time
-
-import openai
-from google import genai
-from google.genai.types import GenerateContentConfig
-
-from app.config import settings
 from app.logging import get_logger
+from app.services.llm_service import call_llm
 from app.transcript import Transcript
 
 
@@ -16,18 +10,8 @@ MAX_CHUNK_SIZE = 30000
 
 
 class SummarizerService:
-    def __init__(self, provider="openai", model="gpt-4o"):
-        self.provider = provider
-        self.model = model
-        if self.provider == "openai":
-            self.client = openai
-            self.client.api_key = settings.OPENAI_API_KEY
-        elif self.provider == "google":
-            self._client = genai.Client(api_key=settings.GOOGLE_API_KEY)
-            if self.model == "gpt-4o":  # Default overwrite for google
-                self.model = "gemini-3-flash-preview"
-        else:
-            raise ValueError(f"Unsupported LLM provider: {provider}")
+    def __init__(self, model_string="openai:gpt-4o"):
+        self.model_string = model_string
 
     def _split_into_chunks(
         self, text: str, max_size: int = MAX_CHUNK_SIZE
@@ -57,7 +41,7 @@ class SummarizerService:
 
     def process(self, transcript: Transcript, **kwargs):
         logger.info(
-            f"Summarizing transcript with {self.provider} (model: {self.model})..."
+            f"Summarizing transcript with model: {self.model_string}..."
         )
         text_to_summarize = transcript.outputs.get(
             "corrected_text", transcript.outputs["raw"]
@@ -142,34 +126,9 @@ Provide a comprehensive summary covering the main topics, key arguments, and imp
 {text}"""
 
         try:
-            if self.provider == "openai":
-                response = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[{"role": "user", "content": prompt}],
-                    timeout=300,  # 5 minute timeout
-                )
-                return response.choices[0].message.content
-            elif self.provider == "google":
-                return self._call_with_retry(prompt, max_tokens=4096)
+            return call_llm(self.model_string, prompt, max_tokens=4096)
         except Exception as e:
             logger.error(f"Error during summarization: {e}")
             return ""
 
-    def _call_with_retry(self, prompt, max_tokens=4096, max_retries=4):
-        """Call Gemini with exponential backoff on 503/429 errors."""
-        config = GenerateContentConfig(max_output_tokens=max_tokens)
-        for attempt in range(max_retries):
-            try:
-                response = self._client.models.generate_content(
-                    model=self.model,
-                    contents=prompt,
-                    config=config,
-                )
-                return response.text
-            except Exception as e:
-                if ("503" in str(e) or "429" in str(e)) and attempt < max_retries - 1:
-                    wait = 2 ** attempt * 5  # 5, 10, 20, 40 seconds
-                    logger.warning(f"Gemini rate limited (attempt {attempt+1}), waiting {wait}s...")
-                    time.sleep(wait)
-                else:
-                    raise
+

--- a/app/services/whisper.py
+++ b/app/services/whisper.py
@@ -60,14 +60,14 @@ class Whisper:
         # Add whisper output file path to transcript's metadata file
         if transcript.metadata_file is not None:
             # Read existing content of the metadata file
-            with open(transcript.metadata_file) as file:
+            with open(transcript.metadata_file, encoding="utf-8") as file:
                 data = json.load(file)
             # Add whisper output
             data["whisper_output"] = os.path.basename(
                 transcription_service_output_file
             )
             # Write the updated dictionary back to the JSON file
-            with open(transcript.metadata_file, "w") as file:
+            with open(transcript.metadata_file, "w", encoding="utf-8") as file:
                 json.dump(data, file, indent=4)
 
         return transcription_service_output_file
@@ -86,7 +86,7 @@ class Whisper:
             type="srt",
         )
         logger.info(f"(whisper) Writing srt to {output_file}...")
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             for index, segment in enumerate(data["segments"]):
                 f.write(f"{index + 1}\n")
                 f.write(
@@ -136,7 +136,8 @@ class Whisper:
             if not transcript.outputs["transcription_service_output_file"]:
                 raise Exception("No 'whisper_output' found in JSON")
             with open(
-                transcript.outputs["transcription_service_output_file"]
+                transcript.outputs["transcription_service_output_file"],
+                encoding="utf-8",
             ) as outfile:
                 transcription_service_output = json.load(outfile)
 

--- a/app/transcription.py
+++ b/app/transcription.py
@@ -43,9 +43,9 @@ class Transcription:
         needs_review=False,
         include_metadata=True,
         correct=False,
-        llm_provider="openai",
-        llm_correction_model="gpt-4o",
-        llm_summary_model="gpt-4o",
+        llm_correction_model="openai:gpt-4o",
+        llm_summary_model="openai:gpt-4o",
+        llm_metadata_model="gemini:gemini-3-flash-preview",
         no_db=False,
     ):
         self.nocleanup = nocleanup
@@ -92,17 +92,17 @@ class Transcription:
         self.processing_services = []
         # Always run metadata extraction first (uses Gemini)
         if not test_mode:
-            self.processing_services.append(MetadataExtractorService())
+            self.processing_services.append(MetadataExtractorService(model_string=llm_metadata_model))
         if correct:
             self.processing_services.append(
                 CorrectionService(
-                    provider=llm_provider, model=llm_correction_model
+                    model_string=llm_correction_model
                 )
             )
         if summarize:
             self.processing_services.append(
                 SummarizerService(
-                    provider=llm_provider, model=llm_summary_model
+                    model_string=llm_summary_model
                 )
             )
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -24,7 +24,7 @@ def decimal_to_sexagesimal(dec):
 
 def check_if_valid_json(file_path):
     try:
-        with open(file_path) as file:
+        with open(file_path, encoding="utf-8") as file:
             json_content = json.load(file)
         return json_content
     except Exception:

--- a/config.ini.example
+++ b/config.ini.example
@@ -6,9 +6,8 @@ github = False
 save_to_markdown = True
 needs_review = False
 one_sentence_per_line = True
-llm_provider = openai
-llm_correction_model = gpt-4o
-llm_summary_model = gpt-4o
+llm_correction_model = openai:gpt-4o
+llm_summary_model = openai:gpt-4o
 
 [development]
 verbose_logging = True

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -116,7 +116,6 @@ async def add_to_queue(
     source: Optional[str] = Form(None),
     source_file: Optional[UploadFile] = File(None),
     correct: bool = Form(False),
-    llm_provider: str = Form("openai"),
     no_db: bool = Form(False),
 ):
     temp_file_path = None
@@ -138,7 +137,6 @@ async def add_to_queue(
             text_output=text,
             needs_review=needs_review,
             correct=correct,
-            llm_provider=llm_provider,
             no_db=no_db,
         )
         if source_file:

--- a/transcriber.py
+++ b/transcriber.py
@@ -217,12 +217,7 @@ correct_transcript = click.option(
     default=settings.config.getboolean("correct", False),
     help="Correct the transcript using the configured LLM provider.",
 )
-llm_provider = click.option(
-    "--llm-provider",
-    type=click.Choice(["openai", "google", "claude"]),
-    default=settings.config.get("llm_provider", "openai"),
-    help="LLM provider for correction and summarization.",
-)
+
 
 no_db = click.option(
     "--no-db",
@@ -302,7 +297,6 @@ add_category = click.option(
 @verbose_logging
 @auto_start_server
 @correct_transcript
-@llm_provider
 @no_db
 def transcribe(
     source: str,
@@ -330,7 +324,6 @@ def transcribe(
     needs_review: bool,
     cutoff_date: str,
     correct: bool,
-    llm_provider: str,
     nocheck: bool,
     no_db: bool,
 ) -> None:
@@ -379,7 +372,6 @@ def transcribe(
         "needs_review": needs_review,
         "cutoff_date": cutoff_date,
         "correct": correct,
-        "llm_provider": llm_provider,
         "nocheck": nocheck,
         "no_db": no_db,
     }


### PR DESCRIPTION
## Summary
This PR consolidates the LLM interaction logic into a central service.

### Change
**Centralised LLM Service**:
   - Created `app/services/llm_service.py` to handle all LLM provider calls (OpenAI, Gemini) in one place.
   - Adopted a unified `provider:model` configuration syntax (e.g., `openai:gpt-4o`, `gemini:gemini-3-flash-preview`).
   - Refactored `CorrectionService`, `SummarizerService`, `ContentClassifier`, and `MetadataExtractorService` to use the new `call_llm` interface.
   - Removed legacy `--llm-provider` CLI and API flags to simplify configuration.
### Impact
- **Improved Extensibility**: Adding new LLM providers (e.g., Claude) now only requires adding a handler in `llm_service.py`.