### PR TITLE
added modular service integration Fixes #21 

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -142,6 +142,10 @@ class Settings:
     def DATABASE_URL(self):
         return os.getenv("DATABASE_URL")
 
+    @property
+    def ASR_PROVIDER(self):
+        return self.config.get("asr_provider", "whisper")
+
 
 # Initialize the Settings class and expose an instance
 settings = Settings()

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,4 +1,3 @@
-from .deepgram import Deepgram  # noqa: F401
+from .factory import get_asr_service  # noqa: F401
 from .metadata_extractor import MetadataExtractorService  # noqa: F401
-from .smallestai import SmallestAI  # noqa: F401
-from .whisper import Whisper  # noqa: F401
+from .providers.base import BaseTranscriptionService  # noqa: F401

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
 import pkgutil
-from typing import Dict, Any
+from typing import Dict
 
 from app.data_writer import DataWriter
 from app.logging import get_logger
@@ -40,10 +40,15 @@ def discover_providers():
         except ImportError as e:
             logger.warning(f"Could not load provider module '{module_name}': {e}")
         except ValueError:
-            # Re-raise validation/collision errors to fail fast
+            _REGISTRY.clear()
             raise
         except Exception as e:
             logger.error(f"Error loading provider module '{module_name}': {e}")
+
+
+def reset_registry():
+    """Clear the provider registry (primarily for testing)."""
+    _REGISTRY.clear()
 
 
 def get_available_providers() -> list[str]:

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import pkgutil
+import threading
 from typing import Dict
 
 from app.data_writer import DataWriter
@@ -10,53 +11,66 @@ from app.services.providers.base import BaseTranscriptionService
 logger = get_logger()
 
 _REGISTRY: Dict[str, type[BaseTranscriptionService]] = {}
+_REGISTRY_LOCK = threading.Lock()
 
 
 def discover_providers():
     """Automatically discover all ASR providers in the providers directory."""
     import app.services.providers as providers
 
-    for _, module_name, _ in pkgutil.iter_modules(providers.__path__):
-        if module_name == "base":
-            continue
+    with _REGISTRY_LOCK:
+        if _REGISTRY:
+            return
+            
+        new_registry = {}
 
-        try:
-            module = importlib.import_module(f"app.services.providers.{module_name}")
-            for name, obj in inspect.getmembers(module, inspect.isclass):
-                if issubclass(obj, BaseTranscriptionService) and obj is not BaseTranscriptionService:
-                    if getattr(obj, "__module__", None) != module.__name__:
-                        continue
-                    
-                    provider_name = getattr(obj, "PROVIDER_NAME", module_name.lower())
-                    if provider_name in _REGISTRY and _REGISTRY[provider_name] is not obj:
-                        existing = _REGISTRY[provider_name]
-                        raise ValueError(
-                            f"Provider name collision during registration: "
-                            f"'{provider_name}' is already registered to "
-                            f"{existing.__module__}.{existing.__name__}. "
-                            f"Cannot register {obj.__module__}.{obj.__name__}."
-                        )
-                    _REGISTRY[provider_name] = obj
-        except ImportError as e:
-            logger.warning(f"Could not load provider module '{module_name}': {e}")
-        except ValueError:
-            _REGISTRY.clear()
-            raise
-        except Exception as e:
-            logger.error(f"Error loading provider module '{module_name}': {e}")
-            raise
+        for _, module_name, _ in pkgutil.iter_modules(providers.__path__):
+            if module_name == "base":
+                continue
+
+            try:
+                module = importlib.import_module(f"app.services.providers.{module_name}")
+                for name, obj in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(obj, BaseTranscriptionService) and obj is not BaseTranscriptionService:
+                        if getattr(obj, "__module__", None) != module.__name__:
+                            continue
+                        
+                        provider_name = getattr(obj, "PROVIDER_NAME", module_name.lower())
+                        if not isinstance(provider_name, str) or not provider_name.strip():
+                            raise ValueError(
+                                f"Invalid PROVIDER_NAME for {obj.__module__}.{obj.__name__}: "
+                                f"must be a non-empty string, got {repr(provider_name)}"
+                            )
+                        if provider_name in new_registry and new_registry[provider_name] is not obj:
+                            existing = new_registry[provider_name]
+                            raise ValueError(
+                                f"Provider name collision during registration: "
+                                f"'{provider_name}' is already registered to "
+                                f"{existing.__module__}.{existing.__name__}. "
+                                f"Cannot register {obj.__module__}.{obj.__name__}."
+                            )
+                        new_registry[provider_name] = obj
+            except ImportError as e:
+                logger.warning(f"Could not load provider module '{module_name}': {e}")
+            except Exception as e:
+                logger.error(f"Error loading provider module '{module_name}': {e}")
+                raise
+                
+        _REGISTRY.update(new_registry)
 
 
 def reset_registry():
     """Clear the provider registry (primarily for testing)."""
-    _REGISTRY.clear()
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
 
 
 def get_available_providers() -> list[str]:
     """Return a list of discovered provider names."""
     if not _REGISTRY:
         discover_providers()
-    return list(_REGISTRY.keys())
+    with _REGISTRY_LOCK:
+        return list(_REGISTRY.keys())
 
 
 def get_asr_service(provider: str, config: dict, metadata_writer: DataWriter) -> BaseTranscriptionService:
@@ -64,9 +78,13 @@ def get_asr_service(provider: str, config: dict, metadata_writer: DataWriter) ->
     if not _REGISTRY:
         discover_providers()
 
-    cls = _REGISTRY.get(provider)
+    with _REGISTRY_LOCK:
+        cls = _REGISTRY.get(provider)
+        available = list(_REGISTRY.keys())
+        
     if cls is None:
         raise ValueError(
-            f"Unknown ASR provider: '{provider}'. Choose from {list(_REGISTRY.keys())}"
+            f"Unknown ASR provider: '{provider}'. Choose from {available}"
         )
     return cls.from_config(config, metadata_writer)
+

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -24,12 +24,30 @@ def discover_providers():
             module = importlib.import_module(f"app.services.providers.{module_name}")
             for name, obj in inspect.getmembers(module, inspect.isclass):
                 if issubclass(obj, BaseTranscriptionService) and obj is not BaseTranscriptionService:
+                    if getattr(obj, "__module__", None) != module.__name__:
+                        continue
+                    
                     provider_name = getattr(obj, "PROVIDER_NAME", module_name.lower())
+                    if provider_name in _REGISTRY and _REGISTRY[provider_name] is not obj:
+                        existing = _REGISTRY[provider_name]
+                        raise ValueError(
+                            f"Provider name collision during registration: "
+                            f"'{provider_name}' is already registered to "
+                            f"{existing.__module__}.{existing.__name__}. "
+                            f"Cannot register {obj.__module__}.{obj.__name__}."
+                        )
                     _REGISTRY[provider_name] = obj
         except ImportError as e:
             logger.warning(f"Could not load provider module '{module_name}': {e}")
         except Exception as e:
             logger.error(f"Error loading provider module '{module_name}': {e}")
+
+
+def get_available_providers() -> list[str]:
+    """Return a list of discovered provider names."""
+    if not _REGISTRY:
+        discover_providers()
+    return list(_REGISTRY.keys())
 
 
 def get_asr_service(provider: str, config: dict, metadata_writer: DataWriter) -> BaseTranscriptionService:

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -1,0 +1,45 @@
+import importlib
+import inspect
+import pkgutil
+from typing import Dict, Any
+
+from app.data_writer import DataWriter
+from app.logging import get_logger
+from app.services.providers.base import BaseTranscriptionService
+
+logger = get_logger()
+
+_REGISTRY: Dict[str, type[BaseTranscriptionService]] = {}
+
+
+def discover_providers():
+    """Automatically discover all ASR providers in the providers directory."""
+    import app.services.providers as providers
+
+    for _, module_name, _ in pkgutil.iter_modules(providers.__path__):
+        if module_name == "base":
+            continue
+
+        try:
+            module = importlib.import_module(f"app.services.providers.{module_name}")
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                if issubclass(obj, BaseTranscriptionService) and obj is not BaseTranscriptionService:
+                    provider_name = getattr(obj, "PROVIDER_NAME", module_name.lower())
+                    _REGISTRY[provider_name] = obj
+        except ImportError as e:
+            logger.warning(f"Could not load provider module '{module_name}': {e}")
+        except Exception as e:
+            logger.error(f"Error loading provider module '{module_name}': {e}")
+
+
+def get_asr_service(provider: str, config: dict, metadata_writer: DataWriter) -> BaseTranscriptionService:
+    """Retrieve the instantiated ASR service for the given provider."""
+    if not _REGISTRY:
+        discover_providers()
+
+    cls = _REGISTRY.get(provider)
+    if cls is None:
+        raise ValueError(
+            f"Unknown ASR provider: '{provider}'. Choose from {list(_REGISTRY.keys())}"
+        )
+    return cls.from_config(config, metadata_writer)

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -39,6 +39,9 @@ def discover_providers():
                     _REGISTRY[provider_name] = obj
         except ImportError as e:
             logger.warning(f"Could not load provider module '{module_name}': {e}")
+        except ValueError:
+            # Re-raise validation/collision errors to fail fast
+            raise
         except Exception as e:
             logger.error(f"Error loading provider module '{module_name}': {e}")
 

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -44,6 +44,7 @@ def discover_providers():
             raise
         except Exception as e:
             logger.error(f"Error loading provider module '{module_name}': {e}")
+            raise
 
 
 def reset_registry():

--- a/app/services/providers/__init__.py
+++ b/app/services/providers/__init__.py
@@ -1,0 +1,1 @@
+# Marking directory as a python package

--- a/app/services/providers/base.py
+++ b/app/services/providers/base.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+from app.data_writer import DataWriter
+from app.transcript import Transcript
+
+class BaseTranscriptionService(ABC):
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config: Dict[str, Any], metadata_writer: DataWriter) -> "BaseTranscriptionService":
+        """Instantiate the transcription service from a configuration dictionary."""
+        pass
+
+    @abstractmethod
+    def transcribe(self, transcript: Transcript) -> None:
+        """Perform the transcription on the given transcript object."""
+        pass
+
+    @abstractmethod
+    def finalize_transcript(self, transcript: Transcript) -> None:
+        """Finalize the transcription formatting and output files."""
+        pass

--- a/app/services/providers/deepgram.py
+++ b/app/services/providers/deepgram.py
@@ -21,11 +21,15 @@ from app.types import (
     SpeakerSegmentWithSentences,
 )
 
+from app.services.providers.base import BaseTranscriptionService
+
 
 logger = get_logger()
 
 
-class Deepgram:
+class DeepgramService(BaseTranscriptionService):
+    PROVIDER_NAME = "deepgram"
+
     def __init__(self, summarize, diarize, upload, data_writer: DataWriter):
         self.summarize = summarize
         self.diarize = diarize
@@ -39,6 +43,18 @@ class Deepgram:
         self.max_audio_length = 3600.0  # 60 minutes in seconds
         self.processor = MediaProcessor(chunk_length=1200.0)
         self.api_key = settings.DEEPGRAM_API_KEY
+
+    def __str__(self):
+        return f"Deepgram(summarize={self.summarize}, diarize={self.diarize})"
+
+    @classmethod
+    def from_config(cls, config: dict, metadata_writer: DataWriter) -> "DeepgramService":
+        return cls(
+            summarize=config.get("summarize", False),
+            diarize=config.get("diarize", False),
+            upload=config.get("upload", False),
+            data_writer=metadata_writer,
+        )
 
     def audio_to_text(self, audio_file, chunk=None):
         language = settings.config.get("language", "en")

--- a/app/services/providers/smallestai.py
+++ b/app/services/providers/smallestai.py
@@ -11,13 +11,16 @@ from app.logging import get_logger
 from app.media_processor import MediaProcessor
 from app.transcript import Transcript
 
+from app.services.providers.base import BaseTranscriptionService
 
 logger = get_logger()
 
 API_URL = "https://waves-api.smallest.ai/api/v1/pulse/get_text"
 
 
-class SmallestAI:
+class SmallestAIService(BaseTranscriptionService):
+    PROVIDER_NAME = "smallestai"
+
     def __init__(self, diarize, upload, data_writer: DataWriter):
         self.diarize = diarize
         self.upload = upload
@@ -32,6 +35,17 @@ class SmallestAI:
         )
         self.max_audio_length = 3600.0  # 60 minutes
         self.processor = MediaProcessor(chunk_length=1200.0)
+
+    def __str__(self):
+        return f"SmallestAI(diarize={self.diarize}, emotion_detection={self.emotion_detection})"
+
+    @classmethod
+    def from_config(cls, config: dict, metadata_writer: DataWriter) -> "SmallestAIService":
+        return cls(
+            diarize=config.get("diarize", False),
+            upload=config.get("upload", False),
+            data_writer=metadata_writer,
+        )
 
     def audio_to_text(self, audio_file, chunk=None):
         """Send audio to SmallestAI Pulse STT API.

--- a/app/services/providers/whisper.py
+++ b/app/services/providers/whisper.py
@@ -7,19 +7,36 @@ from app.logging import get_logger
 from app.transcript import Transcript
 
 
+from app.services.providers.base import BaseTranscriptionService
+
+
 logger = get_logger()
 
 
-class Whisper:
+class WhisperService(BaseTranscriptionService):
+    PROVIDER_NAME = "whisper"
+
     def __init__(self, model, upload, data_writer: DataWriter):
         self.model = model
         self.upload = upload
         self.data_writer = data_writer
         self._whisper = None
 
+    def __str__(self):
+        return f"Whisper(model={self.model})"
+
+    @classmethod
+    def from_config(cls, config: dict, metadata_writer: DataWriter) -> "WhisperService":
+        return cls(
+            model=config.get("model", "tiny.en"),
+            upload=config.get("upload", False),
+            data_writer=metadata_writer,
+        )
+
     def _load_whisper(self):
         if self._whisper is None:
             try:
+                # pyrefly: ignore [missing-import]
                 import whisper
 
                 self._whisper = whisper

--- a/app/transcription.py
+++ b/app/transcription.py
@@ -50,7 +50,7 @@ class Transcription:
         llm_correction_model=None,
         llm_summary_model=None,
         no_db=False,
-        asr_provider=settings.ASR_PROVIDER,
+        asr_provider=None,
     ):
         if llm_provider is None:
             llm_provider = settings.LLM_PROVIDER
@@ -72,6 +72,9 @@ class Transcription:
             raise ValueError("pipeline_retry_delay_seconds must be an integer >= 0")
         self._correct_enabled = correct
         self._summarize_enabled = summarize
+
+        asr_provider = asr_provider or settings.ASR_PROVIDER
+        self.asr_provider_name = asr_provider
         self.nocleanup = nocleanup
         self.status = "idle"
         self.test_mode = test_mode

--- a/app/transcription.py
+++ b/app/transcription.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 
 import yt_dlp
 
-from app import __version__, application, services, utils
+from app import __version__, application, utils
 from app.config import settings
 from app.data_fetcher import DataFetcher
 from app.data_writer import DataWriter
@@ -32,8 +32,6 @@ class Transcription:
         model="tiny",
         github=False,
         summarize=False,
-        deepgram=False,
-        smallestai=False,
         diarize=False,
         upload=False,
         model_output_dir="local_models/",
@@ -52,6 +50,7 @@ class Transcription:
         llm_correction_model=None,
         llm_summary_model=None,
         no_db=False,
+        asr_provider=settings.ASR_PROVIDER,
     ):
         if llm_provider is None:
             llm_provider = settings.LLM_PROVIDER
@@ -144,16 +143,18 @@ class Transcription:
             )
         )
 
-        if deepgram:
-            self.service = services.Deepgram(
-                summarize, diarize, upload, self.metadata_writer
-            )
-        elif smallestai:
-            self.service = services.SmallestAI(
-                diarize, upload, self.metadata_writer
-            )
-        else:
-            self.service = services.Whisper(model, upload, self.metadata_writer)
+        from app.services.factory import get_asr_service
+        self.service = get_asr_service(
+            provider=asr_provider,
+            config={
+                "summarize": summarize,
+                "diarize": diarize,
+                "upload": upload,
+                "model": model,
+            },
+            metadata_writer=self.metadata_writer,
+        )
+        self.logger.info(f"Initialized ASR service: {self.service}")
 
         self.transcripts: list[Transcript] = []
         self.existing_media = None

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,5 +1,5 @@
 [DEFAULT]
-deepgram = True
+asr_provider = whisper
 diarize = True
 summarize = False
 github = False

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -32,11 +32,12 @@ def get_transcription_instance(**kwargs) -> Transcription:
     else:
         # Runtime check to prevent silent ignores of mismatched asr_provider
         requested_provider = kwargs.get("asr_provider")
-        if requested_provider and getattr(transcription_instance, "asr_provider_name", None) != requested_provider:
+        effective_requested_provider = requested_provider or settings.ASR_PROVIDER
+        if getattr(transcription_instance, "asr_provider_name", None) != effective_requested_provider:
             raise ValueError(
                 f"A transcription instance is already running with provider "
                 f"'{transcription_instance.asr_provider_name}'. Cannot queue a task "
-                f"with a different provider ('{requested_provider}')."
+                f"with a different provider ('{effective_requested_provider}')."
             )
     return transcription_instance
 

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -29,6 +29,15 @@ def get_transcription_instance(**kwargs) -> Transcription:
     if transcription_instance is None:
         transcription_instance = Transcription(**kwargs)
         logger.debug(transcription_instance)
+    else:
+        # Runtime check to prevent silent ignores of mismatched asr_provider
+        requested_provider = kwargs.get("asr_provider")
+        if requested_provider and getattr(transcription_instance, "asr_provider_name", None) != requested_provider:
+            raise ValueError(
+                f"A transcription instance is already running with provider "
+                f"'{transcription_instance.asr_provider_name}'. Cannot queue a task "
+                f"with a different provider ('{requested_provider}')."
+            )
     return transcription_instance
 
 
@@ -163,6 +172,9 @@ async def add_to_queue(
             "status": "queued",
             "message": "Transcription source has been added to the queue.",
         }
+    except ValueError as e:
+        logger.error(f"Validation error: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(e)
         traceback.print_exc()

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -174,7 +174,7 @@ async def add_to_queue(
         }
     except ValueError as e:
         logger.error(f"Validation error: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.error(e)
         traceback.print_exc()

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -16,7 +16,7 @@ from fastapi import (
 from app.logging import get_logger
 from app.services.database_service import get_database_service
 from app.transcription import Transcription
-
+from app.config import settings
 
 logger = get_logger()
 router = APIRouter(tags=["Transcription"])
@@ -98,8 +98,7 @@ async def add_to_queue(
     speakers: list[str] = Form([]),
     category: list[str] = Form([]),
     github: bool = Form(False),
-    deepgram: bool = Form(False),
-    smallestai: bool = Form(False),
+    asr_provider: str = Form(settings.ASR_PROVIDER),
     summarize: bool = Form(False),
     diarize: bool = Form(False),
     upload: bool = Form(False),
@@ -125,8 +124,7 @@ async def add_to_queue(
             model=model,
             github=github,
             summarize=summarize,
-            deepgram=deepgram,
-            smallestai=smallestai,
+            asr_provider=asr_provider,
             diarize=diarize,
             upload=upload,
             model_output_dir=model_output_dir,
@@ -244,7 +242,7 @@ async def start(background_tasks: BackgroundTasks):
 
     return {
         "status": "started",
-        "message": "Transcription process has started.",
+        "message": f"Transcription process has started using {transcription.service}.",
     }
 
 

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -107,7 +107,7 @@ async def add_to_queue(
     speakers: list[str] = Form([]),
     category: list[str] = Form([]),
     github: bool = Form(False),
-    asr_provider: str = Form(settings.ASR_PROVIDER),
+    asr_provider: Optional[str] = Form(None),
     summarize: bool = Form(False),
     diarize: bool = Form(False),
     upload: bool = Form(False),

--- a/routes/transcription.py
+++ b/routes/transcription.py
@@ -31,14 +31,15 @@ def get_transcription_instance(**kwargs) -> Transcription:
         logger.debug(transcription_instance)
     else:
         # Runtime check to prevent silent ignores of mismatched asr_provider
-        requested_provider = kwargs.get("asr_provider")
-        effective_requested_provider = requested_provider or settings.ASR_PROVIDER
-        if getattr(transcription_instance, "asr_provider_name", None) != effective_requested_provider:
-            raise ValueError(
-                f"A transcription instance is already running with provider "
-                f"'{transcription_instance.asr_provider_name}'. Cannot queue a task "
-                f"with a different provider ('{effective_requested_provider}')."
-            )
+        if "asr_provider" in kwargs:
+            requested_provider = kwargs.get("asr_provider")
+            effective_requested_provider = requested_provider or settings.ASR_PROVIDER
+            if getattr(transcription_instance, "asr_provider_name", None) != effective_requested_provider:
+                raise ValueError(
+                    f"A transcription instance is already running with provider "
+                    f"'{transcription_instance.asr_provider_name}'. Cannot queue a task "
+                    f"with a different provider ('{effective_requested_provider}')."
+                )
     return transcription_instance
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -22,9 +22,17 @@ def test_get_asr_service_unknown_provider():
     for p in available:
         assert p in error_msg
 
-def test_get_asr_service_success():
+def test_get_asr_service_success(monkeypatch):
     mock_writer = MagicMock()
-    # Assuming "whisper" is always available in the standard install
-    service = get_asr_service("whisper", {}, mock_writer)
+    providers = get_available_providers()
+    if not providers:
+        pytest.fail("No ASR providers discovered")
+    provider_name = providers[0]
+    
+    # Mock environment variables for providers that require them on init
+    if provider_name == "deepgram":
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dummy_key")
+        
+    service = get_asr_service(provider_name, {}, mock_writer)
     assert isinstance(service, BaseTranscriptionService)
-    assert service.__class__.PROVIDER_NAME == "whisper"
+    assert service.__class__.PROVIDER_NAME == provider_name

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -27,12 +27,14 @@ def test_get_asr_service_success(monkeypatch):
     providers = get_available_providers()
     if not providers:
         pytest.fail("No ASR providers discovered")
-    provider_name = providers[0]
-    
+    provider_name = "whisper" if "whisper" in providers else providers[0]
+
     # Mock environment variables for providers that require them on init
     if provider_name == "deepgram":
         monkeypatch.setenv("DEEPGRAM_API_KEY", "dummy_key")
-        
+    elif provider_name == "smallestai":
+        monkeypatch.setenv("SMALLEST_API_KEY", "dummy_key")
+
     service = get_asr_service(provider_name, {}, mock_writer)
     assert isinstance(service, BaseTranscriptionService)
     assert service.__class__.PROVIDER_NAME == provider_name

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,13 @@
 import pytest
 from unittest.mock import MagicMock
-from app.services.factory import get_asr_service, get_available_providers
+from app.services.factory import get_asr_service, get_available_providers, reset_registry
+from app.services.providers.base import BaseTranscriptionService
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    reset_registry()
+    yield
+    reset_registry()
 
 def test_get_asr_service_unknown_provider():
     mock_writer = MagicMock()
@@ -12,6 +19,12 @@ def test_get_asr_service_unknown_provider():
     
     assert "Unknown ASR provider: 'does-not-exist'" in error_msg
     # Check that the available providers are listed in the error message
-    # e.g., "Choose from ['deepgram', 'smallestai', 'whisper']"
     for p in available:
         assert p in error_msg
+
+def test_get_asr_service_success():
+    mock_writer = MagicMock()
+    # Assuming "whisper" is always available in the standard install
+    service = get_asr_service("whisper", {}, mock_writer)
+    assert isinstance(service, BaseTranscriptionService)
+    assert service.__class__.PROVIDER_NAME == "whisper"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,17 @@
+import pytest
+from unittest.mock import MagicMock
+from app.services.factory import get_asr_service, get_available_providers
+
+def test_get_asr_service_unknown_provider():
+    mock_writer = MagicMock()
+    with pytest.raises(ValueError) as excinfo:
+        get_asr_service("does-not-exist", {}, mock_writer)
+    
+    available = get_available_providers()
+    error_msg = str(excinfo.value)
+    
+    assert "Unknown ASR provider: 'does-not-exist'" in error_msg
+    # Check that the available providers are listed in the error message
+    # e.g., "Choose from ['deepgram', 'smallestai', 'whisper']"
+    for p in available:
+        assert p in error_msg

--- a/transcriber.py
+++ b/transcriber.py
@@ -91,19 +91,13 @@ whisper = click.option(
     show_default=True,
     help="Select which whisper model to use for the transcription",
 )
-deepgram = click.option(
-    "-D",
-    "--deepgram",
-    is_flag=True,
-    default=False,
-    help="Use deepgram for transcription",
-)
-smallestai_option = click.option(
-    "--smallestai",
-    is_flag=True,
-    default=settings.config.getboolean("smallestai", False),
+asr_provider_option = click.option(
+    "-p",
+    "--asr-provider",
+    type=str,
+    default=settings.ASR_PROVIDER,
     show_default=True,
-    help="Use SmallestAI Pulse STT for transcription",
+    help="Select which ASR provider to use for the transcription (e.g. whisper, deepgram, smallestai)",
 )
 diarize = click.option(
     "-M",
@@ -272,8 +266,7 @@ add_category = click.option(
 @click.argument("source", nargs=1)
 # Available transcription models and services
 @whisper
-@deepgram
-@smallestai_option
+@asr_provider_option
 # Available features for transcription services
 @diarize
 @summarize
@@ -315,8 +308,7 @@ def transcribe(
     category: list,
     username: str,
     github: bool,
-    deepgram: bool,
-    smallestai: bool,
+    asr_provider: str,
     summarize: bool,
     diarize: bool,
     upload: bool,
@@ -348,10 +340,6 @@ def transcribe(
     url = get_transcription_url()
     api_client = APIClient(url)
 
-    # If user didn't pick a service on CLI, fall back to config defaults
-    if not (deepgram or smallestai):
-        deepgram = settings.config.getboolean("deepgram", False)
-        smallestai = settings.config.getboolean("smallestai", False)
     markdown = markdown or settings.config.getboolean("save_to_markdown", False)
 
     data = {
@@ -364,8 +352,7 @@ def transcribe(
         "category": list(category),
         "username": username,
         "github": github,
-        "deepgram": deepgram,
-        "smallestai": smallestai,
+        "asr_provider": asr_provider,
         "summarize": summarize,
         "diarize": diarize,
         "upload": upload,
@@ -499,8 +486,6 @@ def postprocess(
         configure_logger(log_level=logging.INFO)
         utils.check_if_valid_file_path(metadata_json_file)
         transcription = Transcription(
-            deepgram=service == "deepgram",
-            smallestai=service == "smallestai",
             github=github,
             upload=upload,
             username=username,
@@ -508,6 +493,7 @@ def postprocess(
             text_output=text,
             json=json,
             needs_review=needs_review,
+            asr_provider=service,
         )
         logger.info(
             f"Postprocessing {service} transcript from {metadata_json_file}"

--- a/transcriber.py
+++ b/transcriber.py
@@ -94,7 +94,7 @@ whisper = click.option(
 asr_provider_option = click.option(
     "-p",
     "--asr-provider",
-    type=click.Choice(get_available_providers(), case_sensitive=False),
+    type=str,
     default=settings.ASR_PROVIDER,
     show_default=True,
     help="Select which ASR provider to use for the transcription (e.g. whisper, deepgram, smallestai)",

--- a/transcriber.py
+++ b/transcriber.py
@@ -94,10 +94,10 @@ whisper = click.option(
 asr_provider_option = click.option(
     "-p",
     "--asr-provider",
-    type=str,
+    type=click.Choice(get_available_providers(), case_sensitive=False),
     default=settings.ASR_PROVIDER,
     show_default=True,
-    help=f"Select which ASR provider to use for the transcription (e.g. {', '.join(get_available_providers())})",
+    help="Select which ASR provider to use for the transcription.",
 )
 diarize = click.option(
     "-M",

--- a/transcriber.py
+++ b/transcriber.py
@@ -10,7 +10,7 @@ from app.config import settings
 from app.data_writer import DataWriter
 from app.logging import configure_logger, get_logger
 from app.transcription import Transcription
-
+from app.services.factory import get_available_providers
 
 logger = get_logger()
 
@@ -94,7 +94,7 @@ whisper = click.option(
 asr_provider_option = click.option(
     "-p",
     "--asr-provider",
-    type=str,
+    type=click.Choice(get_available_providers(), case_sensitive=False),
     default=settings.ASR_PROVIDER,
     show_default=True,
     help="Select which ASR provider to use for the transcription (e.g. whisper, deepgram, smallestai)",

--- a/transcriber.py
+++ b/transcriber.py
@@ -97,7 +97,7 @@ asr_provider_option = click.option(
     type=str,
     default=settings.ASR_PROVIDER,
     show_default=True,
-    help="Select which ASR provider to use for the transcription (e.g. whisper, deepgram, smallestai)",
+    help=f"Select which ASR provider to use for the transcription (e.g. {', '.join(get_available_providers())})",
 )
 diarize = click.option(
     "-M",

--- a/transcriber.py
+++ b/transcriber.py
@@ -456,7 +456,7 @@ def preprocess(
 
 @cli.command()
 @click.argument(
-    "service", nargs=1, type=click.Choice(["whisper", "deepgram", "smallestai"])
+    "service", nargs=1, type=click.Choice(get_available_providers(), case_sensitive=False)
 )
 @click.argument("metadata_json_file", nargs=1)
 # Options for configuring the transcription postprocess


### PR DESCRIPTION
Fixes #21 

This PR introduces a major architectural refactor to the ASR (Automatic Speech Recognition) service layer. It transitions from hardcoded service selection to a modular, provider-based system with dynamic discovery and a centralized factory.

## Key Changes

### 1. Abstract ASR Provider Base Class
Introduced `BaseTranscriptionService` in `app/services/providers/base.py`. This standardizes the interface for all ASR services, requiring implementations for:
- `from_config`: Standardized instantiation.
- `transcribe`: Core transcription logic.
- `finalize_transcript`: Post-transcription formatting and cleanup.

### 2. Modular Provider Architecture
Moved existing ASR implementations (Deepgram, SmallestAI, Whisper) to the `app/services/providers/` directory. Each provider now inherits from the base class and implements its own configuration parsing, making it significantly easier to add new ASR backends in the future.

### 3. Dynamic Service Discovery & Factory
Implemented a registry-based factory system in `app/services/factory.py`:
- **`discover_providers`**: Automatically scans the `providers/` package and registers all valid subclasses of `BaseTranscriptionService`.
- **`get_asr_service`**: A centralized entry point for retrieving service instances based on the `ASR_PROVIDER` setting.

### 4. Simplified Pipeline Configuration
Refactored the `Transcription` engine to utilize the new factory. This removes the deep conditional nesting previously used to instantiate services and consolidates service-specific settings into a unified configuration dictionary.

### 5. Configuration Enhancements
- Added `ASR_PROVIDER` to `app/config.py` for global service management.
- Updated `config.ini.example` to reflect the new modular settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the ASR layer into a modular, provider-based system with dynamic discovery and a central factory, replacing boolean flags with a single `asr_provider` setting. Improves CLI/API ergonomics, adds provider validation, and hardens error handling; fixes #21.

- **Refactors**
  - Added `BaseTranscriptionService` (`from_config`, `transcribe`, `finalize_transcript`); providers moved to `app/services/providers/` as `WhisperService`, `DeepgramService`, and `SmallestAIService` with `PROVIDER_NAME` and readable `__str__`.
  - Introduced a thread-safe factory/registry with `discover_providers`, `get_available_providers`, and `get_asr_service`; `Transcription` now uses it, stores `asr_provider_name`, and logs the active service.
  - Unified config/CLI/API: `--asr-provider` and `asr_provider` (default from `settings.ASR_PROVIDER`); CLI transcribe/postprocess use dynamic choices via `get_available_providers()` and validate with `click.Choice`; `config.ini.example` updated.

- **Bug Fixes**
  - Hardened discovery with import guards, module-origin checks, and provider name-collision detection.
  - API returns 400 for provider mismatches or unknown providers (error lists available providers); start responses include the selected service.

<sup>Written for commit a7d5c096519ec6b339b457a08f052fc4fefddc7f. Summary will update on new commits. <a href="https://cubic.dev/pr/genesis-kb/transcription_engine/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select ASR provider by name via config, CLI, or web form; start responses show the selected backend.
  * Runtime discovery and dynamic listing of available ASR providers.

* **Configuration**
  * Single asr_provider setting; default is "whisper".

* **CLI / API**
  * CLI flag and web form accept asr_provider; requests enforce provider consistency for running processes.

* **Tests**
  * Added tests for unknown-provider errors and provider discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesis-kb/transcription_engine/pull/28)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->