### PR TITLE
feat: update database models, migration scripts, and index management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,8 +135,8 @@ dmypy.json
 .username
 .idea
 output/
+outputs/
 test_feats/
 logs/
 metadata/
-scripts/
-.github/.DS_Store
+input/audiobooks/

--- a/app/models.py
+++ b/app/models.py
@@ -234,10 +234,12 @@ class ContentItem(Base):
             else None,
         }
         if include_source and self.source:
+            source_config = self.source.config or {}
             d["content_source"] = {
                 "name": self.source.name,
                 "source_type": self.source.source_type,
                 "slug": self.source.slug,
+                "category": source_config.get("category", ""),
             }
         else:
             d["content_source"] = None
@@ -350,6 +352,9 @@ class Transcript(Base):
     )
 
     __table_args__ = (
+        UniqueConstraint(
+            "content_item_id", "version", name="uq_transcripts_content_item_version"
+        ),
         Index(
             "idx_single_active_transcript",
             "content_item_id",
@@ -512,4 +517,133 @@ class PipelineRun(Base):
             if self.completed_at
             else None,
             "status": self.status,
+        }
+
+
+# =========================================================================
+# 9. AUDIO PLAYLISTS — Learning Tracks
+# =========================================================================
+
+
+class AudioPlaylist(Base):
+    """A curated audio playlist / learning track (e.g. 'Learn Me a Bitcoin')."""
+
+    __tablename__ = "audio_playlists"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    title = Column(Text, nullable=False)
+    slug = Column(Text, unique=True, nullable=False)
+    description = Column(Text)
+    playlist_type = Column(Text, nullable=False)  # 'series', 'collection'
+    cover_image_url = Column(Text)
+    tags = Column(JSONB, server_default=text("'[]'::jsonb"))
+    status = Column(
+        Text, nullable=False, server_default=text("'draft'")
+    )  # 'draft', 'published', 'archived'
+    total_duration_seconds = Column(Integer, server_default=text("0"))
+    episode_count = Column(Integer, server_default=text("0"))
+    created_at = Column(DateTime(timezone=True), server_default=text("now()"))
+    updated_at = Column(DateTime(timezone=True), server_default=text("now()"), onupdate=text("now()"))
+
+    episodes = relationship(
+        "AudioEpisode",
+        back_populates="playlist",
+        cascade="all, delete-orphan",
+        order_by="AudioEpisode.sequence_number",
+    )
+
+    __table_args__ = (
+        Index("idx_playlists_status", "status"),
+        Index("idx_playlists_type", "playlist_type"),
+    )
+
+    def to_dict(self, include_episodes=False):
+        d = {
+            "id": str(self.id),
+            "title": self.title,
+            "slug": self.slug,
+            "description": self.description,
+            "playlist_type": self.playlist_type,
+            "cover_image_url": self.cover_image_url,
+            "tags": self.tags or [],
+            "status": self.status,
+            "total_duration_seconds": self.total_duration_seconds,
+            "episode_count": self.episode_count,
+            "created_at": self.created_at.isoformat()
+            if self.created_at
+            else None,
+            "updated_at": self.updated_at.isoformat()
+            if self.updated_at
+            else None,
+        }
+        if include_episodes:
+            d["episodes"] = [ep.to_dict() for ep in self.episodes]
+        return d
+
+
+# =========================================================================
+# 10. AUDIO EPISODES — Individual Audio Units
+# =========================================================================
+
+
+class AudioEpisode(Base):
+    """A single audio episode within a playlist."""
+
+    __tablename__ = "audio_episodes"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    playlist_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audio_playlists.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title = Column(Text, nullable=False)
+    description = Column(Text)
+    sequence_number = Column(Integer, nullable=False)
+    audio_url = Column(Text)
+    duration_seconds = Column(Integer)
+    source_url = Column(Text)
+    status = Column(
+        Text, nullable=False, server_default=text("'pending'")
+    )  # 'pending', 'generating', 'completed', 'failed'
+    chapters = Column(JSONB, server_default=text("'[]'::jsonb"))
+    metadata_ = Column("metadata", JSONB, server_default=text("'{}'::jsonb"))
+    created_at = Column(DateTime(timezone=True), server_default=text("now()"))
+
+    playlist = relationship("AudioPlaylist", back_populates="episodes")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "playlist_id",
+            "sequence_number",
+            name="uq_episodes_playlist_sequence",
+        ),
+        Index("idx_episodes_playlist", "playlist_id"),
+        Index("idx_episodes_status", "status"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": str(self.id),
+            "playlist_id": str(self.playlist_id) if self.playlist_id else None,
+            "title": self.title,
+            "description": self.description,
+            "sequence_number": self.sequence_number,
+            "audio_url": self.audio_url,
+            "duration_seconds": self.duration_seconds,
+            "source_url": self.source_url,
+            "status": self.status,
+            "chapters": self.chapters or [],
+            "metadata": self.metadata_ or {},
+            "created_at": self.created_at.isoformat()
+            if self.created_at
+            else None,
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ PyYAML==6.0.1
 librosa==0.10.2.post1
 fastapi==0.111.0
 uvicorn>=0.30.0
-PyJWT==2.9.0
+PyJWT>=2.13.0
 cryptography==43.0.1
 psutil==7.0.0
 openai==1.98.0
@@ -27,3 +27,7 @@ psycopg2-binary>=2.9.0
 google-genai>=0.8.0
 google-generativeai>=0.3.2
 google-api-python-client>=2.100.0
+pydub>=0.25
+audioop-lts>=0.2; python_version >= '3.13'
+num2words>=0.5.13
+nltk>=3.9.4

--- a/scripts/add_indexes.py
+++ b/scripts/add_indexes.py
@@ -26,55 +26,64 @@ def add_indexes():
 
     index_sqls = [
         # content_sources
-        "CREATE INDEX IF NOT EXISTS idx_sources_type ON content_sources(source_type);",
-        "CREATE INDEX IF NOT EXISTS idx_sources_active ON content_sources(is_active) WHERE is_active = true;",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sources_type ON content_sources(source_type);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sources_active ON content_sources(is_active) WHERE is_active = true;",
         
         # content_items
-        "CREATE INDEX IF NOT EXISTS idx_items_source ON content_items(source_id);",
-        "CREATE INDEX IF NOT EXISTS idx_items_event ON content_items(event_id);",
-        "CREATE INDEX IF NOT EXISTS idx_items_status ON content_items(status);",
-        "CREATE INDEX IF NOT EXISTS idx_items_type ON content_items(content_type);",
-        "CREATE INDEX IF NOT EXISTS idx_items_published ON content_items(published_at DESC);",
-        "CREATE INDEX IF NOT EXISTS idx_items_technical ON content_items(technical_score) WHERE technical_score >= 4;",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_source ON content_items(source_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_event ON content_items(event_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_status ON content_items(status);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_type ON content_items(content_type);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_published ON content_items(published_at DESC);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_technical ON content_items(technical_score) WHERE technical_score >= 4;",
         
         # content_items FTS (Titles & Descriptions)
         """
-        CREATE INDEX IF NOT EXISTS idx_items_fts 
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_fts 
         ON content_items USING GIN(to_tsvector('english', COALESCE(title, '') || ' ' || COALESCE(description, '')));
         """,
         
         # content_item_speakers
-        "CREATE INDEX IF NOT EXISTS idx_cis_speaker ON content_item_speakers(speaker_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cis_speaker ON content_item_speakers(speaker_id);",
         
         # taxonomies
-        "CREATE INDEX IF NOT EXISTS idx_taxonomies_parent ON taxonomies(parent_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_taxonomies_parent ON taxonomies(parent_id);",
         
         # transcripts FTS (GIN index on tsvector) - Partial index only for active transcripts
         """
-        CREATE INDEX IF NOT EXISTS idx_transcripts_fts 
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transcripts_fts 
         ON transcripts USING GIN(to_tsvector('english', COALESCE(corrected_text, raw_text, '')))
         WHERE is_current = true;
         """,
         
         # summaries
-        "CREATE INDEX IF NOT EXISTS idx_summaries_type ON summaries(summary_type);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_summaries_type ON summaries(summary_type);",
         
         # summaries FTS (GIN index on tsvector)
         """
-        CREATE INDEX IF NOT EXISTS idx_summaries_fts 
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_summaries_fts 
         ON summaries USING GIN(to_tsvector('english', COALESCE(content, '')));
         """
     ]
 
-    with engine.connect() as conn:
-        with conn.begin():
-            # Postgres GIN indexes require the pg_trgm extension for some advanced text operations,
-            # though to_tsvector doesn't strictly need it, it's good to have.
-            conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pg_trgm";'))
-            
-            for sql in index_sqls:
-                logger.info(f"Executing: {sql.strip().split(chr(10))[0]}...")
-                conn.execute(text(sql))
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        # Postgres GIN indexes require the pg_trgm extension for some advanced text operations,
+        # though to_tsvector doesn't strictly need it, it's good to have.
+        add_pg_trgm_extension = os.getenv("ADD_PG_TRGM_EXTENSION", "true").lower() in ("1", "true", "yes", "on")
+        if add_pg_trgm_extension:
+            try:
+                conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pg_trgm";'))
+            except Exception as e:
+                logger.warning(
+                    f'Could not create optional PostgreSQL extension "pg_trgm": {e}. '
+                    "Continuing with index creation."
+                )
+        else:
+            logger.info('Skipping optional PostgreSQL extension creation for "pg_trgm".')
+        
+        for sql in index_sqls:
+            logger.info(f"Executing: {sql.strip().split(chr(10))[0]}...")
+            conn.execute(text(sql))
 
     logger.info("All indexes created successfully!")
 

--- a/scripts/migrate_schema.py
+++ b/scripts/migrate_schema.py
@@ -5,8 +5,7 @@ import json
 import logging
 import argparse
 from datetime import datetime, timezone
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import text
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -79,18 +78,53 @@ def run_migration(dry_run=False):
             # 4. Migrate Data
             logger.info("Migrating data from old_youtube_channels -> content_sources...")
             migrate_sources_sql = """
+                WITH source_rows AS (
+                    SELECT
+                        id,
+                        channel_name,
+                        channel_url,
+                        channel_id,
+                        category,
+                        priority,
+                        is_active,
+                        created_at,
+                        LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g')) AS base_slug
+                    FROM old_youtube_channels
+                ),
+                deduped_source_rows AS (
+                    SELECT
+                        id,
+                        channel_name,
+                        channel_url,
+                        channel_id,
+                        category,
+                        priority,
+                        is_active,
+                        created_at,
+                        CASE
+                            WHEN COUNT(*) OVER (PARTITION BY base_slug) > 1 THEN base_slug || '-' || id
+                            ELSE base_slug
+                        END AS slug
+                    FROM source_rows
+                )
                 INSERT INTO content_sources (id, name, slug, source_type, base_url, config, is_active, last_run_status, created_at)
-                SELECT 
-                    id, 
-                    channel_name, 
-                    LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g')), 
-                    'youtube', 
-                    channel_url, 
-                    jsonb_build_object('yt_channel_id', channel_id, 'category', category, 'priority', priority), 
-                    is_active, 
-                    NULL, 
+                SELECT
+                    id,
+                    channel_name,
+                    slug,
+                    'youtube',
+                    channel_url,
+                    jsonb_build_object('yt_channel_id', channel_id, 'category', category, 'priority', priority),
+                    is_active,
+                    NULL,
                     created_at
-                FROM old_youtube_channels;
+                FROM deduped_source_rows
+                ON CONFLICT (slug) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    base_url = EXCLUDED.base_url,
+                    config = EXCLUDED.config,
+                    is_active = EXCLUDED.is_active,
+                    created_at = EXCLUDED.created_at;
             """
             if not dry_run:
                 res = conn.execute(text(migrate_sources_sql))
@@ -136,14 +170,29 @@ def run_migration(dry_run=False):
                 manual_source_id = conn.execute(text("""
                     INSERT INTO content_sources (name, slug, source_type, is_active)
                     VALUES ('Manual Imports', 'manual-imports', 'manual', true)
+                    ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
                     RETURNING id;
                 """)).scalar()
 
-                transcripts = conn.execute(text("SELECT * FROM old_transcripts")).fetchall()
-                logger.info(f"Processing {len(transcripts)} old transcripts...")
+                total_transcripts = conn.execute(text("SELECT COUNT(*) FROM old_transcripts")).scalar()
+                logger.info(f"Processing {total_transcripts} old transcripts in batches...")
                 
+                def iter_transcripts():
+                    last_id = None
+                    batch_size = 100
+                    while True:
+                        if last_id is None:
+                            batch = conn.execute(text("SELECT * FROM old_transcripts ORDER BY id LIMIT :limit"), {"limit": batch_size}).fetchall()
+                        else:
+                            batch = conn.execute(text("SELECT * FROM old_transcripts WHERE id > :last_id ORDER BY id LIMIT :limit"), {"limit": batch_size, "last_id": last_id}).fetchall()
+                        if not batch:
+                            break
+                        for row in batch:
+                            yield row
+                        last_id = batch[-1].id
+
                 migrated_transcripts_count = 0
-                for t in transcripts:
+                for t in iter_transcripts():
                     t_id = t.id
                     raw = t.raw_text
                     corrected = t.corrected_text
@@ -164,17 +213,19 @@ def run_migration(dry_run=False):
                     
                     if not content_item_id:
                         ext_id = video_id if video_id else f"manual-{t_id}"
+                        db_url = t.media_url if t.media_url else None
                         row = conn.execute(text("""
                             INSERT INTO content_items (source_id, external_id, title, content_type, url, status)
                             VALUES (:s_id, :ext_id, :title, 'video', :url, 'transcribed')
                             ON CONFLICT (source_id, external_id) DO UPDATE SET title = EXCLUDED.title
                             RETURNING id;
-                        """), {"s_id": manual_source_id, "ext_id": ext_id, "title": t.title or 'Unknown', "url": t.media_url}).first()
+                        """), {"s_id": manual_source_id, "ext_id": ext_id, "title": t.title or 'Unknown', "url": db_url}).first()
                         content_item_id = row[0]
 
                     conn.execute(text("""
                         INSERT INTO transcripts (id, content_item_id, is_current, version, raw_text, corrected_text, created_at)
                         VALUES (:t_id, :ci_id, true, 1, :raw, :corr, :created_at)
+                        ON CONFLICT (id) DO NOTHING
                     """), {"t_id": t_id, "ci_id": content_item_id, "raw": raw, "corr": corrected, "created_at": t.created_at})
                     migrated_transcripts_count += 1
                     
@@ -218,6 +269,22 @@ def run_migration(dry_run=False):
             if not dry_run:
                 res = conn.execute(text(migrate_runs_sql))
                 logger.info(f"Migrated {res.rowcount} pipeline runs.")
+                
+                # Link sources to their latest pipeline runs (must run after pipeline_runs are populated)
+                update_last_run_sql = """
+                    UPDATE content_sources cs
+                    SET last_run_id = pr.id,
+                        last_run_status = pr.status
+                    FROM (
+                        SELECT id, source_id, status,
+                               ROW_NUMBER() OVER(PARTITION BY source_id ORDER BY started_at DESC) as rn
+                        FROM pipeline_runs
+                        WHERE source_id IS NOT NULL
+                    ) pr
+                    WHERE cs.id = pr.source_id AND pr.rn = 1;
+                """
+                conn.execute(text(update_last_run_sql))
+                logger.info("Linked content_sources to their latest pipeline runs.")
             else:
                 logger.info(f"DRY RUN: {migrate_runs_sql}")
 

--- a/test/exporters/test_base.py
+++ b/test/exporters/test_base.py
@@ -7,7 +7,7 @@ from app.exporters import TranscriptExporter
 
 
 # Create concrete subclass for testing abstract base class
-class TestableExporter(TranscriptExporter):
+class DummyExporter(TranscriptExporter):
     """Concrete implementation of TranscriptExporter for testing"""
 
     def export(self, transcript, **kwargs):
@@ -28,7 +28,7 @@ class TestTranscriptExporter:
     @pytest.fixture
     def base_exporter(self, temp_dir):
         """Create an instance of the concrete subclass for testing"""
-        return TestableExporter(temp_dir)
+        return DummyExporter(temp_dir)
 
     def test_construct_file_path_with_timestamp(self, base_exporter):
         """Test file path construction with timestamp"""

--- a/test/exporters/test_json.py
+++ b/test/exporters/test_json.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from app.exporters import JsonExporter
+from app.utils import slugify
 
 
 @pytest.mark.unit
@@ -35,7 +36,7 @@ class TestJsonExporter:
         expected_path = os.path.join(
             temp_dir,
             mock_transcript.source.loc,
-            f"{mock_transcript.title}.json",
+            f"{slugify(mock_transcript.title)}.json",
         )
         assert os.path.abspath(result) == os.path.abspath(expected_path)
 

--- a/test/exporters/test_markdown.py
+++ b/test/exporters/test_markdown.py
@@ -41,7 +41,7 @@ class TestMarkdownExporter:
         assert "This is a test transcript." in content
 
         # Verify the file path
-        assert os.path.basename(result).startswith("Test Transcript")
+        assert os.path.basename(result).startswith("test-transcript")
         assert result.endswith(".md")
 
     def test_export_without_metadata(

--- a/test/exporters/test_text.py
+++ b/test/exporters/test_text.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from app.exporters import TextExporter
+from app.utils import slugify
 
 
 @pytest.mark.unit
@@ -27,7 +28,7 @@ class TestTextExporter:
 
         # Check file path
         expected_path = os.path.join(
-            temp_dir, mock_transcript.source.loc, f"{mock_transcript.title}.txt"
+            temp_dir, mock_transcript.source.loc, f"{slugify(mock_transcript.title)}.txt"
         )
         assert os.path.abspath(result) == os.path.abspath(expected_path)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add audio playlist and episode models, and improve schema migration and index creation to support audiobook tracks and faster, safer deployments.

- **New Features**
  - Added `AudioPlaylist` and `AudioEpisode` models with relations, unique constraints, and indexes; `AudioPlaylist.to_dict(include_episodes)` support.
  - Enforced `Transcript` uniqueness per `content_item_id` + `version`; `to_dict(include_source)` now includes `content_source.category`.
  - Index script now uses `CREATE INDEX CONCURRENTLY` with autocommit and optional `"pg_trgm"` via `ADD_PG_TRGM_EXTENSION`.
  - Updated deps: `PyJWT>=2.13.0`; added `pydub`, `audioop-lts` (py3.13+), `num2words`, `nltk`.

- **Migration**
  - Source migration deduplicates slugs and upserts into `content_sources` with preserved config and activity flags.
  - Transcript migration runs in batches, upserts `content_items` (using `media_url` when present), and skips existing transcripts on conflict.
  - After migrating runs, `content_sources` now link to their latest `pipeline_runs` (`last_run_id`/`last_run_status`).

<sup>Written for commit 4f5df6926a99cf711648ded29c323b06e801f0a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/genesis-kb/transcription_engine/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

