### PR TITLE
Audio-book orchestration

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -518,3 +518,132 @@ class PipelineRun(Base):
             else None,
             "status": self.status,
         }
+
+
+# =========================================================================
+# 9. AUDIO PLAYLISTS — Learning Tracks
+# =========================================================================
+
+
+class AudioPlaylist(Base):
+    """A curated audio playlist / learning track (e.g. 'Learn Me a Bitcoin')."""
+
+    __tablename__ = "audio_playlists"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    title = Column(Text, nullable=False)
+    slug = Column(Text, unique=True, nullable=False)
+    description = Column(Text)
+    playlist_type = Column(Text, nullable=False)  # 'series', 'collection'
+    cover_image_url = Column(Text)
+    tags = Column(JSONB, server_default=text("'[]'::jsonb"))
+    status = Column(
+        Text, nullable=False, server_default=text("'draft'")
+    )  # 'draft', 'published', 'archived'
+    total_duration_seconds = Column(Integer, server_default=text("0"))
+    episode_count = Column(Integer, server_default=text("0"))
+    created_at = Column(DateTime(timezone=True), server_default=text("now()"))
+    updated_at = Column(DateTime(timezone=True), server_default=text("now()"), onupdate=text("now()"))
+
+    episodes = relationship(
+        "AudioEpisode",
+        back_populates="playlist",
+        cascade="all, delete-orphan",
+        order_by="AudioEpisode.sequence_number",
+    )
+
+    __table_args__ = (
+        Index("idx_playlists_status", "status"),
+        Index("idx_playlists_type", "playlist_type"),
+    )
+
+    def to_dict(self, include_episodes=False):
+        d = {
+            "id": str(self.id),
+            "title": self.title,
+            "slug": self.slug,
+            "description": self.description,
+            "playlist_type": self.playlist_type,
+            "cover_image_url": self.cover_image_url,
+            "tags": self.tags or [],
+            "status": self.status,
+            "total_duration_seconds": self.total_duration_seconds,
+            "episode_count": self.episode_count,
+            "created_at": self.created_at.isoformat()
+            if self.created_at
+            else None,
+            "updated_at": self.updated_at.isoformat()
+            if self.updated_at
+            else None,
+        }
+        if include_episodes:
+            d["episodes"] = [ep.to_dict() for ep in self.episodes]
+        return d
+
+
+# =========================================================================
+# 10. AUDIO EPISODES — Individual Audio Units
+# =========================================================================
+
+
+class AudioEpisode(Base):
+    """A single audio episode within a playlist."""
+
+    __tablename__ = "audio_episodes"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    playlist_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("audio_playlists.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title = Column(Text, nullable=False)
+    description = Column(Text)
+    sequence_number = Column(Integer, nullable=False)
+    audio_url = Column(Text)
+    duration_seconds = Column(Integer)
+    source_url = Column(Text)
+    status = Column(
+        Text, nullable=False, server_default=text("'pending'")
+    )  # 'pending', 'generating', 'completed', 'failed'
+    chapters = Column(JSONB, server_default=text("'[]'::jsonb"))
+    metadata_ = Column("metadata", JSONB, server_default=text("'{}'::jsonb"))
+    created_at = Column(DateTime(timezone=True), server_default=text("now()"))
+
+    playlist = relationship("AudioPlaylist", back_populates="episodes")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "playlist_id",
+            "sequence_number",
+            name="uq_episodes_playlist_sequence",
+        ),
+        Index("idx_episodes_playlist", "playlist_id"),
+        Index("idx_episodes_status", "status"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": str(self.id),
+            "playlist_id": str(self.playlist_id) if self.playlist_id else None,
+            "title": self.title,
+            "description": self.description,
+            "sequence_number": self.sequence_number,
+            "audio_url": self.audio_url,
+            "duration_seconds": self.duration_seconds,
+            "source_url": self.source_url,
+            "status": self.status,
+            "chapters": self.chapters or [],
+            "metadata": self.metadata_ or {},
+            "created_at": self.created_at.isoformat()
+            if self.created_at
+            else None,
+        }

--- a/app/services/audiobook/curator.py
+++ b/app/services/audiobook/curator.py
@@ -1,0 +1,352 @@
+"""Audiobook curation orchestrator.
+
+The curator is the brain of the pipeline. It:
+  1. Reads parsed input files (from ingestion.py)
+  2. Decides single-article vs. series strategy
+  3. Calls the audio pipeline for TTS generation
+  4. Persists results via the playlist service
+
+Usage:
+    from app.services.audiobook.curator import AudiobookCurator
+    curator = AudiobookCurator()
+    result = curator.curate_from_directory("input/audiobooks")
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from app.logging import get_logger
+
+from .ingestion import InputFile, group_series, scan_input_directory
+from .pipeline import AudioPipeline
+from .playlist_service import PlaylistService
+
+
+logger = get_logger()
+
+# Articles above this word count are split into chapters via LLM.
+# Below this threshold they become a single-chapter episode.
+DEFAULT_CHAPTERIZE_THRESHOLD = 5000
+
+
+def _slugify(text: str) -> str:
+    """Convert a title into a URL-safe slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[-\s]+", "-", text)
+    return text.strip("-") or "untitled"
+
+
+class AudiobookCurator:
+    """Orchestrates the full curation flow: ingest → generate → persist."""
+
+    def __init__(
+        self,
+        chapterize_threshold: int = DEFAULT_CHAPTERIZE_THRESHOLD,
+        skip_llm: bool = False,
+        provider_override: Optional[str] = None,
+        diarize: bool = False,
+    ):
+        self._pipeline = AudioPipeline()
+        self._playlists = PlaylistService()
+        self._chapterize_threshold = chapterize_threshold
+        self._skip_llm = skip_llm
+        self._provider_override = provider_override
+        self._diarize = diarize
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def curate_from_directory(
+        self, input_dir: str | Path
+    ) -> dict[str, Any]:
+        """Scan a directory and process all text files.
+
+        Returns a summary dict with counts and any errors.
+        """
+        logger.info(f"[curator] Scanning {input_dir}...")
+        inputs = scan_input_directory(input_dir)
+        if not inputs:
+            logger.info("[curator] No files to process")
+            return self._summary(0, 0, [])
+
+        # Separate single articles from series files
+        singles = [
+            f for f in inputs if f.input_type == "single_article"
+        ]
+        series_groups = group_series(inputs)
+
+        episodes_generated = 0
+        playlists_touched = 0
+        errors: list[str] = []
+
+        # Process series groups
+        for slug, files in series_groups.items():
+            try:
+                result = self._process_series(slug, files)
+                episodes_generated += result["episodes"]
+                playlists_touched += 1
+            except Exception as e:
+                msg = f"Series '{slug}' failed: {e}"
+                logger.error(msg)
+                errors.append(msg)
+
+        # Process single articles
+        for inp in singles:
+            try:
+                result = self._process_single_article(inp)
+                episodes_generated += result["episodes"]
+                playlists_touched += 1
+            except Exception as e:
+                msg = f"Article '{inp.title}' failed: {e}"
+                logger.error(msg)
+                errors.append(msg)
+
+        summary = self._summary(
+            episodes_generated, playlists_touched, errors
+        )
+        logger.info(
+            f"[curator] Done! {episodes_generated} episode(s) generated, "
+            f"{playlists_touched} playlist(s) touched"
+        )
+        return summary
+
+    def curate_single_text(
+        self,
+        text: str,
+        title: str,
+        playlist_slug: Optional[str] = None,
+        playlist_title: Optional[str] = None,
+        source_url: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+    ) -> dict:
+        """Programmatic API: generate audio from raw text and add to a
+        playlist.
+
+        If no playlist_slug is given, one is derived from the title.
+        """
+        slug = playlist_slug or _slugify(title)
+        pl_title = playlist_title or title
+
+        playlist = self._playlists.find_or_create_playlist(
+            slug=slug,
+            title=pl_title,
+            playlist_type="collection",
+            tags=tags,
+        )
+
+        seq = self._playlists.get_next_sequence_number(playlist["id"])
+        episode = self._playlists.create_episode(
+            playlist_id=playlist["id"],
+            title=title,
+            sequence_number=seq,
+            source_url=source_url,
+        )
+
+        should_skip_llm = (
+            self._skip_llm or len(text.split()) <= self._chapterize_threshold
+        )
+        self._generate_and_update(episode, text, should_skip_llm)
+        self._playlists.refresh_playlist_stats(playlist["id"])
+
+        return {
+            "playlist": self._playlists.get_playlist_by_id(
+                playlist["id"]
+            ),
+            "episode": self._playlists.get_episode_by_id(
+                episode["id"]
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal: Series Processing
+    # ------------------------------------------------------------------
+
+    def _process_series(
+        self, slug: str, files: list[InputFile]
+    ) -> dict[str, int]:
+        """Process a group of series files into one playlist."""
+        series_title = files[0].series_title or files[0].title
+        tags = files[0].tags if files[0].tags else []
+
+        logger.info(
+            f"[curator] Series '{series_title}': {len(files)} file(s)"
+        )
+
+        playlist = self._playlists.find_or_create_playlist(
+            slug=slug,
+            title=series_title,
+            playlist_type="series",
+            tags=tags,
+        )
+
+        generated = 0
+        for inp in files:
+            episode, created = self._playlists.find_or_create_episode(
+                playlist_id=playlist["id"],
+                title=inp.title,
+                sequence_number=inp.sequence_number,
+                source_url=inp.source_url,
+                description=inp.description,
+                metadata={
+                    "author": inp.author,
+                    "word_count": inp.word_count,
+                    "source_file": inp.filepath.name,
+                },
+            )
+
+            # Series episodes are already logically divided — no LLM
+            if self._generate_and_update(
+                episode, inp.body, skip_llm=True
+            ):
+                generated += 1
+
+        self._playlists.refresh_playlist_stats(playlist["id"])
+        return {"episodes": generated}
+
+    # ------------------------------------------------------------------
+    # Internal: Single Article Processing
+    # ------------------------------------------------------------------
+
+    def _process_single_article(
+        self, inp: InputFile
+    ) -> dict[str, int]:
+        """Process a single standalone article."""
+        slug = _slugify(inp.title)
+        logger.info(
+            f"[curator] Article '{inp.title}' — "
+            f"{inp.word_count} words"
+        )
+
+        playlist = self._playlists.find_or_create_playlist(
+            slug=slug,
+            title=inp.title,
+            playlist_type="collection",
+            description=inp.description,
+            tags=inp.tags,
+        )
+
+        seq = self._playlists.get_next_sequence_number(playlist["id"])
+        episode, created = self._playlists.find_or_create_episode(
+            playlist_id=playlist["id"],
+            title=inp.title,
+            sequence_number=seq,
+            source_url=inp.source_url,
+            description=inp.description,
+            metadata={
+                "author": inp.author,
+                "word_count": inp.word_count,
+                "source_file": inp.filepath.name,
+            },
+        )
+
+        # Use LLM chapterization only for long articles
+        should_skip_llm = (
+            self._skip_llm
+            or inp.word_count <= self._chapterize_threshold
+        )
+        if self._generate_and_update(episode, inp.body, should_skip_llm):
+            episodes_count = 1
+        else:
+            episodes_count = 0
+        self._playlists.refresh_playlist_stats(playlist["id"])
+        return {"episodes": episodes_count}
+
+    # ------------------------------------------------------------------
+    # Internal: Audio Generation + DB Update
+    # ------------------------------------------------------------------
+
+    def _generate_and_update(
+        self,
+        episode: dict,
+        text: str,
+        skip_llm: bool,
+    ) -> bool:
+        """Run the audio pipeline and update the episode record.
+        
+        Skips episodes that already completed (safe for re-runs).
+        Re-attempts episodes that are in 'pending' or 'failed' status.
+        
+        Returns True if newly generated, False if skipped.
+        """
+        episode_id = episode["id"]
+
+        # Skip if already successfully generated
+        if episode.get("status") == "completed":
+            logger.info(
+                f"  ↩ Skipping '{episode['title']}' (already completed)"
+            )
+            return False
+
+        # Mark as generating
+        self._playlists.update_episode(
+            episode_id, {"status": "generating"}
+        )
+
+        try:
+            result = self._pipeline.generate_episode(
+                text=text,
+                title=episode["title"],
+                output_dir=Path("outputs/audiobooks") / episode_id,
+                skip_llm=skip_llm,
+                provider_override=self._provider_override,
+                diarize=self._diarize,
+            )
+
+            audio_url = str(result.audio_path.absolute())
+            
+            # Optional Supabase upload
+            from .storage import upload_to_supabase
+            playlist = self._playlists.get_playlist_by_id(episode["playlist_id"])
+            playlist_title = playlist["title"] if playlist else "Unknown"
+            
+            # Use same path format as manual seeds: audiobooks/Playlist_Title/Episode_Title.mp3
+            safe_pl_title = "".join(c if c.isalnum() or c in " _-" else "" for c in playlist_title).strip()
+            safe_ep_title = "".join(c if c.isalnum() or c in " _-" else "" for c in episode["title"]).replace(" ", "_")
+            ext = result.audio_path.suffix
+            destination_path = f"{safe_pl_title}/{safe_ep_title}{ext}"
+            
+            public_url = upload_to_supabase(result.audio_path, "audiobooks", destination_path)
+            if public_url:
+                audio_url = public_url
+
+            self._playlists.update_episode(
+                episode_id,
+                {
+                    "audio_url": audio_url,
+                    "duration_seconds": result.duration_seconds,
+                    "chapters": result.chapters,
+                    "status": "completed",
+                },
+            )
+            logger.info(
+                f"  ✓ Episode '{episode['title']}' — "
+                f"{result.duration_seconds}s"
+            )
+            return True
+        except Exception as e:
+            self._playlists.update_episode(
+                episode_id, {"status": "failed"}
+            )
+            logger.error(
+                f"  ✗ Episode '{episode['title']}' failed: {e}"
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _summary(
+        episodes: int, playlists: int, errors: list[str]
+    ) -> dict[str, Any]:
+        return {
+            "episodes_generated": episodes,
+            "playlists_touched": playlists,
+            "errors": errors,
+            "success": len(errors) == 0,
+        }

--- a/app/services/audiobook/curator.py
+++ b/app/services/audiobook/curator.py
@@ -287,10 +287,13 @@ class AudiobookCurator:
         )
 
         try:
+            paths_cfg = self._pipeline.cfg.get("paths") or {}
+            base_output = Path(paths_cfg.get("output_dir") or "outputs/audiobooks")
+            
             result = self._pipeline.generate_episode(
                 text=text,
                 title=episode["title"],
-                output_dir=Path("outputs/audiobooks") / episode_id,
+                output_dir=base_output / episode_id,
                 skip_llm=skip_llm,
                 provider_override=self._provider_override,
                 diarize=self._diarize,

--- a/app/services/audiobook/ingestion.py
+++ b/app/services/audiobook/ingestion.py
@@ -99,6 +99,9 @@ def parse_file(filepath: Path) -> Optional[InputFile]:
 
     try:
         meta = yaml.safe_load(match.group(1)) or {}
+        if not isinstance(meta, dict):
+            logger.error(f"Invalid YAML frontmatter in {filepath.name}: not a mapping")
+            return None
     except yaml.YAMLError as e:
         logger.error(f"Invalid YAML frontmatter in {filepath.name}: {e}")
         return None
@@ -109,12 +112,30 @@ def parse_file(filepath: Path) -> Optional[InputFile]:
         return None
 
     input_type = meta.get("type", "single_article")
+    if input_type not in ("single_article", "series"):
+        logger.error(
+            f"Unsupported input type '{input_type}' in {filepath.name}, skipping"
+        )
+        return None
+        
     title = meta.get("title", filepath.stem.replace("_", " ").title())
 
     if input_type == "series":
         if not meta.get("series_slug"):
             logger.error(
                 f"Series file {filepath.name} missing 'series_slug', "
+                "skipping"
+            )
+            return None
+        if "sequence_number" not in meta:
+            logger.error(
+                f"Series file {filepath.name} missing 'sequence_number', "
+                "skipping"
+            )
+            return None
+        if "series_title" not in meta:
+            logger.error(
+                f"Series file {filepath.name} missing 'series_title', "
                 "skipping"
             )
             return None

--- a/app/services/audiobook/ingestion.py
+++ b/app/services/audiobook/ingestion.py
@@ -1,0 +1,199 @@
+"""Input file parser for the audiobook curation pipeline.
+
+Reads text files with YAML frontmatter metadata from an input directory.
+Supports two input types:
+  - single_article: standalone content (newsletter, blog post)
+  - series: one page of a multi-page guide (e.g. learnmeabitcoin)
+
+Expected file format:
+    ---
+    type: series
+    series_slug: learn-me-a-bitcoin
+    series_title: Learn Me a Bitcoin
+    sequence_number: 1
+    title: Introduction
+    ---
+    Body text here...
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from app.logging import get_logger
+
+
+logger = get_logger()
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+@dataclass
+class InputFile:
+    """Parsed representation of a single input text file."""
+
+    filepath: Path
+    input_type: str              # 'single_article' or 'series'
+    title: str
+    body: str
+
+    # Series-specific fields
+    series_slug: Optional[str] = None
+    series_title: Optional[str] = None
+    sequence_number: int = 1
+
+    # Common optional fields
+    author: Optional[str] = None
+    source_url: Optional[str] = None
+    description: Optional[str] = None
+    tags: list[str] = field(default_factory=list)
+
+    @property
+    def word_count(self) -> int:
+        return len(self.body.split())
+
+
+def _parse_tags(raw_tags: object) -> list[str]:
+    if not raw_tags:
+        return []
+    if isinstance(raw_tags, str):
+        return [raw_tags]
+    if isinstance(raw_tags, list):
+        return [str(t) for t in raw_tags]
+    return [str(raw_tags)]
+
+
+def parse_file(filepath: Path) -> Optional[InputFile]:
+    """Parse a single text file with YAML frontmatter.
+
+    Returns None if the file cannot be parsed or has no valid metadata.
+    """
+    try:
+        raw = filepath.read_text(encoding="utf-8")
+    except Exception as e:
+        logger.error(f"Cannot read file {filepath}: {e}")
+        return None
+
+    match = FRONTMATTER_RE.match(raw)
+    if not match:
+        # No frontmatter — treat as a plain single article
+        body = raw.strip()
+        if not body:
+            logger.warning(f"Empty body in {filepath.name}, skipping")
+            return None
+
+        logger.info(
+            f"No YAML frontmatter in {filepath.name}, "
+            "treating as single_article"
+        )
+        return InputFile(
+            filepath=filepath,
+            input_type="single_article",
+            title=filepath.stem.replace("_", " ").replace("-", " ").title(),
+            body=body,
+        )
+
+    try:
+        meta = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as e:
+        logger.error(f"Invalid YAML frontmatter in {filepath.name}: {e}")
+        return None
+
+    body = raw[match.end():].strip()
+    if not body:
+        logger.warning(f"Empty body in {filepath.name}, skipping")
+        return None
+
+    input_type = meta.get("type", "single_article")
+    title = meta.get("title", filepath.stem.replace("_", " ").title())
+
+    if input_type == "series":
+        if not meta.get("series_slug"):
+            logger.error(
+                f"Series file {filepath.name} missing 'series_slug', "
+                "skipping"
+            )
+            return None
+        try:
+            seq = int(meta.get("sequence_number", 1))
+        except (ValueError, TypeError):
+            logger.error(
+                f"Invalid sequence_number in {filepath.name}: "
+                f"{meta.get('sequence_number')!r}, skipping"
+            )
+            return None
+        return InputFile(
+            filepath=filepath,
+            input_type="series",
+            title=title,
+            body=body,
+            series_slug=meta["series_slug"],
+            series_title=meta.get("series_title", title),
+            sequence_number=seq,
+            author=meta.get("author"),
+            source_url=meta.get("source_url"),
+            description=meta.get("description"),
+            tags=_parse_tags(meta.get("tags")),
+        )
+
+    # single_article (default)
+    return InputFile(
+        filepath=filepath,
+        input_type="single_article",
+        title=title,
+        body=body,
+        author=meta.get("author"),
+        source_url=meta.get("source_url"),
+        description=meta.get("description"),
+        tags=_parse_tags(meta.get("tags")),
+    )
+
+
+def scan_input_directory(input_dir: str | Path) -> list[InputFile]:
+    """Scan a directory for .txt files and parse each one.
+
+    Returns a list of successfully parsed InputFile objects.
+    """
+    input_path = Path(input_dir)
+    if not input_path.is_dir():
+        logger.error(f"Input directory does not exist: {input_path}")
+        return []
+
+    files = sorted(input_path.glob("*.txt"))
+    if not files:
+        logger.info(f"No .txt files found in {input_path}")
+        return []
+
+    parsed: list[InputFile] = []
+    for f in files:
+        result = parse_file(f)
+        if result:
+            parsed.append(result)
+
+    logger.info(
+        f"Scanned {len(files)} file(s), "
+        f"parsed {len(parsed)} successfully"
+    )
+    return parsed
+
+
+def group_series(inputs: list[InputFile]) -> dict[str, list[InputFile]]:
+    """Group series-type InputFiles by their series_slug.
+
+    Returns a dict mapping series_slug → list of InputFile sorted by
+    sequence_number.
+    """
+    groups: dict[str, list[InputFile]] = {}
+    for inp in inputs:
+        if inp.input_type == "series" and inp.series_slug:
+            groups.setdefault(inp.series_slug, []).append(inp)
+
+    # Sort each group by sequence_number
+    for slug in groups:
+        groups[slug].sort(key=lambda x: x.sequence_number)
+
+    return groups

--- a/app/services/audiobook/pipeline.py
+++ b/app/services/audiobook/pipeline.py
@@ -120,7 +120,7 @@ class AudioPipeline:
         clean_txt = clean_text(text, retain_speakers=diarize)
 
         # Step 2: Optionally rewrite via LLM
-        if skip_llm:
+        if skip_llm or diarize:
             manifest = {
                 "title": title,
                 "chapters": [{"title": title, "text": clean_txt}],
@@ -146,11 +146,8 @@ class AudioPipeline:
         base_output = Path(paths_cfg.get("output_dir") or DEFAULT_OUTPUT_DIR)
         cache_dir = Path(paths_cfg.get("cache_dir") or DEFAULT_CACHE_DIR)
 
+        safe_title = "".join(c if c.isalnum() or c in " -_" else "" for c in title).strip() or "episode"
         if output_dir is None:
-            safe_title = "".join(
-                c if c.isalnum() or c in " -_" else ""
-                for c in title
-            ).strip() or "episode"
             output_dir = base_output / safe_title
 
         # Step 3+4: Normalize → chunk → TTS per chapter
@@ -176,7 +173,10 @@ class AudioPipeline:
             audio_chunks = []
             for spk_chunk in speaker_chunks:
                 speaker = spk_chunk["speaker"]
-                spoken = normalize(spk_chunk["text"])
+                spoken = spk_chunk["text"]
+                if hasattr(provider, "apply_lexicon_fallback"):
+                    spoken = provider.apply_lexicon_fallback(spoken)
+                spoken = normalize(spoken)
                 pieces = chunk_split(spoken, cap)
                 
                 original_voice = provider.voice
@@ -199,7 +199,6 @@ class AudioPipeline:
 
         # Step 5: Stitch into final file
         logger.info("[pipeline] Stitching final audio")
-        safe_title = "".join(c if c.isalnum() or c in " -_" else "" for c in title).strip() or "episode"
         final_path = output_dir / f"{safe_title}.{fmt}"
         export_book(chapters_audio, cfg, final_path)
 

--- a/app/services/audiobook/pipeline.py
+++ b/app/services/audiobook/pipeline.py
@@ -1,0 +1,254 @@
+"""Core audio generation pipeline.
+
+Pure audio-processing engine: text in → audio files out.
+Does NOT write to the database — that responsibility belongs to the
+curator, which calls this pipeline and then persists the results.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from pydub import AudioSegment
+
+from app.logging import get_logger
+
+from .config import load_audiobook_config
+from .tts import make_provider, TTSProvider
+from .textproc import clean_text, normalize, chunk_split, parse_diarization
+from .rewrite import rewrite
+from .stitch import build_chapter, export_segment, export_book
+
+
+logger = get_logger()
+
+# Default output and cache directories (relative to project root)
+DEFAULT_OUTPUT_DIR = Path("outputs/audiobooks")
+DEFAULT_CACHE_DIR = Path(".cache/audiobooks")
+
+
+@dataclass
+class GeneratedEpisode:
+    """Result of generating audio for a single episode."""
+
+    title: str
+    audio_path: Path
+    duration_seconds: int
+    chapters: list[dict]
+
+
+def _cache_key(provider: str, voice: str, fmt: str, text: str, lex_hash: str = "", speed: float = 1.0, model: str = "") -> str:
+    h = hashlib.sha256(
+        f"{provider}|{voice}|{fmt}|{text}|{lex_hash}|{speed}|{model}".encode("utf-8")
+    )
+    return h.hexdigest()[:24]
+
+
+def _get_or_synthesize(
+    cache_dir: Path, provider: TTSProvider, text: str
+) -> bytes:
+    """Synthesize a text chunk, using a local file cache."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    lex_str = str(sorted(provider.lexicon.items())) if getattr(provider, "lexicon", None) else ""
+    lex_hash = hashlib.md5(lex_str.encode("utf-8")).hexdigest()[:8] if lex_str else ""
+    key = _cache_key(
+        provider.name, provider.voice, provider.fmt, text, lex_hash,
+        getattr(provider, "speed", 1.0), getattr(provider, "model", "") or ""
+    )
+    path = cache_dir / f"{key}.{provider.fmt}"
+    if path.exists():
+        return path.read_bytes()
+    audio = provider.synthesize(text)
+    path.write_bytes(audio)
+    return audio
+
+
+class AudioPipeline:
+    """Stateless audio generation pipeline.
+
+    Converts raw text → cleaned text → (optional LLM rewrite) →
+    TTS chunks → stitched audio file.
+    """
+
+    def __init__(
+        self,
+        cfg: Optional[dict[str, Any]] = None,
+        lexicon: Optional[dict[str, str]] = None,
+    ):
+        if cfg is None or lexicon is None:
+            default_cfg, default_lexicon = load_audiobook_config()
+            
+        self.cfg = cfg if cfg is not None else default_cfg
+        self.lexicon = lexicon if lexicon is not None else default_lexicon
+
+    def generate_episode(
+        self,
+        text: str,
+        title: str = "Untitled",
+        output_dir: Optional[Path] = None,
+        skip_llm: bool = False,
+        provider_override: Optional[str] = None,
+        diarize: bool = False,
+    ) -> GeneratedEpisode:
+        """Generate a single audio episode from raw text.
+
+        Args:
+            text: Raw body text to convert.
+            title: Episode title (used for the output filename).
+            output_dir: Where to write the final MP3. Defaults to
+                        outputs/audiobooks/<title-slug>/.
+            skip_llm: If True, skip the OpenAI rewrite step.
+            provider_override: Force a specific TTS provider.
+            diarize: If True, parse speaker tags and assign dynamic voices.
+
+        Returns:
+            A GeneratedEpisode with the path, duration, and chapter list.
+        """
+        cfg = dict(self.cfg)
+        if provider_override:
+            cfg["tts"] = dict(cfg["tts"])
+            cfg["tts"]["provider"] = provider_override
+
+        provider = make_provider(cfg, self.lexicon)
+        cap = cfg["tts"]["max_chars"][cfg["tts"]["provider"]]
+        fmt = cfg["tts"]["format"]
+
+        # Step 1: Clean
+        logger.info(f"[pipeline] Cleaning text for '{title}' (diarize={diarize})")
+        clean_txt = clean_text(text, retain_speakers=diarize)
+
+        # Step 2: Optionally rewrite via LLM
+        if skip_llm:
+            manifest = {
+                "title": title,
+                "chapters": [{"title": title, "text": clean_txt}],
+            }
+        else:
+            logger.info(
+                f"[pipeline] LLM rewrite via {cfg['llm']['model']}"
+            )
+            manifest = rewrite(clean_txt, cfg)
+            manifest["title"] = title  # preserve caller's title
+
+        chapters = manifest.get("chapters", [])
+        if not chapters:
+            logger.warning(
+                "[pipeline] LLM rewrite returned no chapters, "
+                "falling back to single chapter from cleaned text"
+            )
+            chapters = [{"title": title, "text": clean_txt}]
+            manifest["chapters"] = chapters
+
+        # Resolve output and cache directories from config, with defaults
+        paths_cfg = cfg.get("paths") or {}
+        base_output = Path(paths_cfg.get("output_dir") or DEFAULT_OUTPUT_DIR)
+        cache_dir = Path(paths_cfg.get("cache_dir") or DEFAULT_CACHE_DIR)
+
+        if output_dir is None:
+            safe_title = "".join(
+                c if c.isalnum() or c in " -_" else ""
+                for c in title
+            ).strip() or "episode"
+            output_dir = base_output / safe_title
+
+        # Step 3+4: Normalize → chunk → TTS per chapter
+        chapters_audio: list[AudioSegment] = []
+        logger.info(
+            f"[pipeline] TTS via {provider.name} ({provider.voice})"
+        )
+        # Keep a persistent voice map across chapters for consistent diarization
+        speaker_voice_map = {}
+        voice_idx = 0
+        available_voices = [provider.voice]
+        if provider.name == "deepgram":
+            available_voices = ["aura-asteria-en", "aura-orion-en", "aura-arcas-en", "aura-perseus-en", "aura-helios-en", "aura-angus-en"]
+        elif provider.name == "smallest":
+            available_voices = ["emily", "james", "lucy", "michael", "sarah"]
+
+        for ci, ch in enumerate(chapters, 1):
+            if diarize:
+                speaker_chunks = parse_diarization(ch["text"])
+            else:
+                speaker_chunks = [{"speaker": "default", "text": ch["text"]}]
+                
+            audio_chunks = []
+            for spk_chunk in speaker_chunks:
+                speaker = spk_chunk["speaker"]
+                spoken = normalize(spk_chunk["text"])
+                pieces = chunk_split(spoken, cap)
+                
+                original_voice = provider.voice
+                if speaker != "default":
+                    if speaker not in speaker_voice_map:
+                        speaker_voice_map[speaker] = available_voices[voice_idx % len(available_voices)]
+                        voice_idx += 1
+                    provider.voice = speaker_voice_map[speaker]
+                
+                for p in pieces:
+                    audio_chunks.append(_get_or_synthesize(cache_dir, provider, p))
+                    
+                provider.voice = original_voice
+                
+            seg = build_chapter(audio_chunks, cfg)
+            export_segment(
+                seg, output_dir / f"ch{ci:02d}.{fmt}", fmt
+            )
+            chapters_audio.append(seg)
+
+        # Step 5: Stitch into final file
+        logger.info("[pipeline] Stitching final audio")
+        safe_title = "".join(c if c.isalnum() or c in " -_" else "" for c in title).strip() or "episode"
+        final_path = output_dir / f"{safe_title}.{fmt}"
+        export_book(chapters_audio, cfg, final_path)
+
+        # Compute duration
+        final_audio = AudioSegment.from_file(final_path)
+        duration_seconds = int(len(final_audio) / 1000)
+
+        return GeneratedEpisode(
+            title=title,
+            audio_path=final_path,
+            duration_seconds=duration_seconds,
+            chapters=chapters,
+        )
+
+
+# =====================================================================
+# Backwards-compatible wrapper (preserves old import path)
+# =====================================================================
+
+class AudiobookService:
+    """Legacy wrapper — delegates to AudioPipeline + PlaylistService."""
+
+    def __init__(self):
+        self._pipeline = AudioPipeline()
+
+    def generate_from_text(
+        self,
+        text: str,
+        skip_llm: bool = False,
+        provider_override: Optional[str] = None,
+        diarize: bool = False,
+        **kwargs,
+    ) -> Optional[dict]:
+        """Generate audio from raw text and return a result dict."""
+        try:
+            result = self._pipeline.generate_episode(
+                text=text,
+                title=kwargs.get("title", "Full Text Audiobook"),
+                skip_llm=skip_llm,
+                provider_override=provider_override,
+                diarize=diarize,
+            )
+            return {
+                "title": result.title,
+                "audio_url": str(result.audio_path.absolute()),
+                "duration_seconds": result.duration_seconds,
+                "chapters": result.chapters,
+                "status": "completed",
+            }
+        except Exception as e:
+            logger.error(f"Audio generation failed: {e}")
+            return None

--- a/app/services/audiobook/playlist_service.py
+++ b/app/services/audiobook/playlist_service.py
@@ -1,0 +1,335 @@
+"""Database CRUD service for audio playlists and episodes.
+
+Pure data-access layer — no business logic. All methods return dicts
+(never raw ORM objects) to avoid detached-session issues.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import joinedload
+
+from app.database import get_session
+from app.logging import get_logger
+from app.models import AudioEpisode, AudioPlaylist
+
+
+logger = get_logger()
+
+
+class PlaylistService:
+    """CRUD operations for audio_playlists and audio_episodes tables."""
+
+    # ------------------------------------------------------------------
+    # Playlists
+    # ------------------------------------------------------------------
+
+    def find_or_create_playlist(
+        self,
+        slug: str,
+        title: str,
+        playlist_type: str = "series",
+        description: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+    ) -> dict:
+        """Return existing playlist by slug, or create a new one."""
+        with get_session() as session:
+            pl = (
+                session.query(AudioPlaylist)
+                .filter_by(slug=slug)
+                .first()
+            )
+            if pl:
+                return pl.to_dict()
+
+            pl = AudioPlaylist(
+                title=title,
+                slug=slug,
+                playlist_type=playlist_type,
+                description=description,
+                tags=tags or [],
+                status="draft",
+            )
+            session.add(pl)
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                pl = (
+                    session.query(AudioPlaylist)
+                    .filter_by(slug=slug)
+                    .first()
+                )
+                if pl:
+                    return pl.to_dict()
+                raise
+            logger.info(f"Created playlist: {title} ({slug})")
+            return pl.to_dict()
+
+    def get_playlist_by_slug(self, slug: str) -> Optional[dict]:
+        """Fetch a single playlist by slug, including episodes."""
+        with get_session() as session:
+            pl = (
+                session.query(AudioPlaylist)
+                .options(joinedload(AudioPlaylist.episodes))
+                .filter_by(slug=slug)
+                .first()
+            )
+            return pl.to_dict(include_episodes=True) if pl else None
+
+    def get_playlist_by_id(self, playlist_id: str) -> Optional[dict]:
+        """Fetch a single playlist by UUID."""
+        with get_session() as session:
+            pl = (
+                session.query(AudioPlaylist)
+                .options(joinedload(AudioPlaylist.episodes))
+                .filter_by(id=playlist_id)
+                .first()
+            )
+            return pl.to_dict(include_episodes=True) if pl else None
+
+    def count_playlists(
+        self,
+        status: Optional[str] = None,
+        playlist_type: Optional[str] = None,
+    ) -> int:
+        """Count total playlists matching the filters."""
+        with get_session() as session:
+            query = session.query(AudioPlaylist)
+            if status:
+                query = query.filter_by(status=status)
+            if playlist_type:
+                query = query.filter_by(playlist_type=playlist_type)
+            return query.count()
+
+    def list_playlists(
+        self,
+        status: Optional[str] = None,
+        playlist_type: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """List playlists with optional filters."""
+        with get_session() as session:
+            query = session.query(AudioPlaylist).order_by(
+                AudioPlaylist.updated_at.desc()
+            )
+            if status:
+                query = query.filter_by(status=status)
+            if playlist_type:
+                query = query.filter_by(playlist_type=playlist_type)
+            objs = query.offset(offset).limit(limit).all()
+            return [pl.to_dict() for pl in objs]
+
+    def update_playlist(
+        self, playlist_id: str, updates: dict
+    ) -> Optional[dict]:
+        """Update playlist fields."""
+        with get_session() as session:
+            pl = (
+                session.query(AudioPlaylist)
+                .filter_by(id=playlist_id)
+                .first()
+            )
+            if not pl:
+                return None
+            for key, value in updates.items():
+                if hasattr(pl, key):
+                    setattr(pl, key, value)
+            pl.updated_at = datetime.now(timezone.utc)
+            session.commit()
+            return pl.to_dict()
+
+    def refresh_playlist_stats(self, playlist_id: str) -> Optional[dict]:
+        """Recalculate total_duration_seconds and episode_count from
+        completed episodes."""
+        with get_session() as session:
+            pl = (
+                session.query(AudioPlaylist)
+                .filter_by(id=playlist_id)
+                .first()
+            )
+            if not pl:
+                return None
+
+            stats = (
+                session.query(
+                    func.count(AudioEpisode.id),
+                    func.coalesce(
+                        func.sum(AudioEpisode.duration_seconds), 0
+                    ),
+                )
+                .filter_by(playlist_id=playlist_id, status="completed")
+                .first()
+            )
+            pl.episode_count = stats[0]
+            pl.total_duration_seconds = stats[1]
+            pl.updated_at = datetime.now(timezone.utc)
+            session.commit()
+            return pl.to_dict()
+
+    def delete_playlist(self, playlist_id: str) -> bool:
+        """Delete a playlist and all its episodes (CASCADE)."""
+        with get_session() as session:
+            pl = (
+                session.query(AudioPlaylist)
+                .filter_by(id=playlist_id)
+                .first()
+            )
+            if not pl:
+                return False
+            session.delete(pl)
+            session.commit()
+            return True
+
+    # ------------------------------------------------------------------
+    # Episodes
+    # ------------------------------------------------------------------
+
+    def find_or_create_episode(
+        self,
+        playlist_id: str,
+        title: str,
+        sequence_number: int,
+        source_url: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> tuple[dict, bool]:
+        """Return an existing episode by (playlist_id, sequence_number),
+        or create a new one in 'pending' status.
+
+        Returns:
+            (episode_dict, created) — created=True if a new row was inserted.
+        """
+        with get_session() as session:
+            ep = (
+                session.query(AudioEpisode)
+                .filter_by(
+                    playlist_id=playlist_id,
+                    sequence_number=sequence_number,
+                )
+                .first()
+            )
+            if ep:
+                logger.info(
+                    f"Episode #{sequence_number} already exists: "
+                    f"'{ep.title}' (status={ep.status})"
+                )
+                return ep.to_dict(), False
+
+            ep = AudioEpisode(
+                playlist_id=playlist_id,
+                title=title,
+                sequence_number=sequence_number,
+                source_url=source_url,
+                description=description,
+                metadata_=metadata or {},
+                status="pending",
+            )
+            session.add(ep)
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                ep = (
+                    session.query(AudioEpisode)
+                    .filter_by(
+                        playlist_id=playlist_id,
+                        sequence_number=sequence_number,
+                    )
+                    .first()
+                )
+                if ep:
+                    return ep.to_dict(), False
+                raise
+            logger.info(
+                f"Created episode #{sequence_number}: {title}"
+            )
+            return ep.to_dict(), True
+
+    # Keep old name as alias for backwards compatibility
+    def create_episode(
+        self,
+        playlist_id: str,
+        title: str,
+        sequence_number: int,
+        source_url: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> dict:
+        """Create a new episode (raises on duplicate). Use
+        find_or_create_episode for idempotent behaviour."""
+        ep, created = self.find_or_create_episode(
+            playlist_id=playlist_id,
+            title=title,
+            sequence_number=sequence_number,
+            source_url=source_url,
+            description=description,
+            metadata=metadata,
+        )
+        if not created:
+            raise ValueError(
+                f"Episode #{sequence_number} already exists in playlist "
+                f"{playlist_id}"
+            )
+        return ep
+
+    def update_episode(
+        self, episode_id: str, updates: dict
+    ) -> Optional[dict]:
+        """Update episode fields (status, audio_url, duration, etc.)."""
+        with get_session() as session:
+            ep = (
+                session.query(AudioEpisode)
+                .filter_by(id=episode_id)
+                .first()
+            )
+            if not ep:
+                return None
+            for key, value in updates.items():
+                if key == "metadata":
+                    ep.metadata_ = value
+                elif hasattr(ep, key):
+                    setattr(ep, key, value)
+            session.commit()
+            return ep.to_dict()
+
+    def get_episode_by_id(self, episode_id: str) -> Optional[dict]:
+        """Fetch a single episode by UUID."""
+        with get_session() as session:
+            ep = (
+                session.query(AudioEpisode)
+                .filter_by(id=episode_id)
+                .first()
+            )
+            return ep.to_dict() if ep else None
+
+    def get_episodes_for_playlist(
+        self, playlist_id: str
+    ) -> list[dict]:
+        """Get all episodes for a playlist, ordered by sequence."""
+        with get_session() as session:
+            eps = (
+                session.query(AudioEpisode)
+                .filter_by(playlist_id=playlist_id)
+                .order_by(AudioEpisode.sequence_number)
+                .all()
+            )
+            return [ep.to_dict() for ep in eps]
+
+    def get_next_sequence_number(self, playlist_id: str) -> int:
+        """Return the next available sequence_number for a playlist."""
+        with get_session() as session:
+            result = (
+                session.query(
+                    func.coalesce(
+                        func.max(AudioEpisode.sequence_number), 0
+                    )
+                )
+                .filter_by(playlist_id=playlist_id)
+                .scalar()
+            )
+            return result + 1

--- a/app/services/audiobook/rewrite.py
+++ b/app/services/audiobook/rewrite.py
@@ -64,7 +64,7 @@ def rewrite(text: str, cfg: dict[str, Any]) -> dict[str, Any]:
             title = str(title)
         if not isinstance(text_val, str):
             text_val = str(text_val)
-        if not title.strip():
+        if not title.strip() or not text_val.strip():
             continue
         valid_chapters.append({"title": title.strip(), "text": text_val})
             

--- a/app/services/audiobook/stitch.py
+++ b/app/services/audiobook/stitch.py
@@ -23,7 +23,10 @@ def build_chapter(chunks: list[bytes], cfg: dict[str, Any]) -> AudioSegment:
         segments.append(gap)
         segments.append(_seg(c, fmt))
         
-    return first._spawn(b"".join(s.raw_data for s in segments))
+    res = segments[0]
+    for s in segments[1:]:
+        res += s
+    return res
 
 def normalize_loudness(seg: AudioSegment, target_dbfs: float) -> AudioSegment:
     if seg.dBFS == float("-inf"): return seg
@@ -50,6 +53,8 @@ def export_book(chapters: list[AudioSegment], cfg: dict[str, Any], out_path: Pat
         segments.append(gap)
         segments.append(ch)
         
-    book = first._spawn(b"".join(s.raw_data for s in segments))
+    book = segments[0]
+    for s in segments[1:]:
+        book += s
     book = normalize_loudness(book, cfg["audio"]["target_dbfs"])
     return export_segment(book, out_path, cfg["tts"]["format"])

--- a/app/services/audiobook/storage.py
+++ b/app/services/audiobook/storage.py
@@ -29,8 +29,9 @@ def upload_to_supabase(file_path: Path, bucket_name: str, destination_path: str)
     }
     
     try:
+        timeout_val = float(os.environ.get("SUPABASE_UPLOAD_TIMEOUT", 300))
         with open(file_path, "rb") as f:
-            response = requests.post(url, headers=headers, data=f, timeout=30)
+            response = requests.post(url, headers=headers, data=f, timeout=(10, timeout_val))
             response.raise_for_status()
             
         public_url = f"{supabase_url.rstrip('/')}/storage/v1/object/public/{bucket_name}/{safe_destination}"

--- a/app/services/audiobook/textproc.py
+++ b/app/services/audiobook/textproc.py
@@ -97,7 +97,7 @@ def _expand_acronym(m: re.Match) -> str:
         return m.group(0)
     expanded = "-".join(word)
     if plural:
-        expanded += "-s"
+        expanded += "s"
     return expanded
 
 def normalize(text: str) -> str:
@@ -121,6 +121,8 @@ PROSODY_SPLIT = re.compile(r'(?<=[;:,\—\-])\s+')
 SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
 
 def chunk_split(text: str, max_chars: int) -> list[str]:
+    if max_chars <= 0:
+        raise ValueError("max_chars must be a positive integer")
     if nltk:
         try:
             sentences = nltk.tokenize.sent_tokenize(text.strip())

--- a/app/services/audiobook/tts.py
+++ b/app/services/audiobook/tts.py
@@ -38,7 +38,7 @@ class TTSProvider(ABC):
 
 class DeepgramTTS(TTSProvider):
     name = "deepgram"
-    supported_formats = {"mp3", "wav", "linear16"}
+    supported_formats = {"mp3", "wav"}
 
     def synthesize(self, text: str) -> bytes:
         text = self.apply_lexicon_fallback(text)
@@ -56,7 +56,7 @@ class DeepgramTTS(TTSProvider):
 
 class SmallestTTS(TTSProvider):
     name = "smallest"
-    supported_formats = {"mp3", "wav", "pcm"}
+    supported_formats = {"mp3", "wav"}
 
     def synthesize(self, text: str) -> bytes:
         text = self.apply_lexicon_fallback(text)

--- a/app/services/audiobook_config.yaml
+++ b/app/services/audiobook_config.yaml
@@ -2,7 +2,6 @@ llm:
   provider: openai
   model: gpt-4.1          # rewrite/chapterize model
   temperature: 0.3
-  max_words_per_request: 2500   # split long input before sending to the LLM
 
 tts:
   provider: deepgram      # deepgram | smallest  (switch to A/B your credits)
@@ -24,7 +23,6 @@ audio:
   target_dbfs: -20.0      # simple loudness normalization target
 
 paths:
-  input_dir: input
-  output_dir: output
-  cache_dir: .cache
+  output_dir: outputs/audiobooks
+  cache_dir: .cache/audiobooks
   lexicon: audiobook_lexicon.json

--- a/app/services/audiobook_service.py
+++ b/app/services/audiobook_service.py
@@ -1,0 +1,11 @@
+# Proxy module — re-exports from the modularized audiobook package.
+from .audiobook.pipeline import AudiobookService, AudioPipeline
+from .audiobook.curator import AudiobookCurator
+from .audiobook.playlist_service import PlaylistService
+
+__all__ = [
+    "AudiobookService",
+    "AudioPipeline",
+    "AudiobookCurator",
+    "PlaylistService",
+]

--- a/app/services/content_classifier.py
+++ b/app/services/content_classifier.py
@@ -130,7 +130,7 @@ class ContentClassifier:
         # Get channel info from joined data
         source_info = item.get("content_source") or {}
         channel_name = source_info.get("name", "")
-        channel_category = source_info.get("category", source_info.get("slug", "unknown"))
+        channel_category = source_info.get("category") or source_info.get("slug", "unknown")
 
         title = item.get("title", "")
         description = item.get("description", "")

--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -389,7 +389,6 @@ class DatabaseService:
             with get_session() as session:
                 rows = (
                     session.query(ContentItem.external_id)
-                    .filter(ContentItem.source_id == source_id)
                     .filter(ContentItem.external_id.in_(external_ids))
                     .all()
                 )

--- a/docs/audiobook-pipeline-how-to-run.md
+++ b/docs/audiobook-pipeline-how-to-run.md
@@ -105,33 +105,38 @@ Files with no `---` block are automatically treated as a single article. The fil
 
 ### Full pipeline (recommended)
 
-```bash
-python curate_audiobooks.py
+Create a Python script (e.g., `run_curator.py`) to curate a whole directory:
+
+```python
+from app.services.audiobook.curator import AudiobookCurator
+
+curator = AudiobookCurator()
+curator.curate_from_directory("input/audiobooks")
 ```
 
-Reads all `.txt` files from `input/audiobooks/`, runs LLM chapterization on articles over 5,000 words, generates audio, and saves everything to the database.
+### Common overrides
 
-### Common flags
+You can override defaults by passing arguments to the `AudiobookCurator`:
 
-```bash
+```python
 # Skip the OpenAI rewrite step (faster and cheaper)
-python curate_audiobooks.py --skip-llm
+curator = AudiobookCurator(skip_llm=True)
 
 # Point at a specific directory (avoids re-processing other files)
-python curate_audiobooks.py --input-dir input/audiobooks/networking
+curator.curate_from_directory("input/audiobooks/networking")
 
 # Override TTS provider
-python curate_audiobooks.py --provider smallest
-python curate_audiobooks.py --provider deepgram
+curator = AudiobookCurator(provider_override="smallest")
 
 # Enable multi-speaker diarization
-python curate_audiobooks.py --diarize
+curator = AudiobookCurator(diarize=True)
 
-# Combine flags
-python curate_audiobooks.py --input-dir input/audiobooks/networking --skip-llm --provider smallest
-
-# Change the word count threshold for LLM chapterization (default: 5000)
-python curate_audiobooks.py --threshold 3000
+# Combine overrides and change threshold
+curator = AudiobookCurator(
+    skip_llm=True, 
+    provider_override="smallest", 
+    chapterize_threshold=3000
+)
 ```
 
 > **Tip:** Use `--input-dir` to target a specific subfolder when you only want to process new files. This prevents the pipeline from re-scanning (and potentially re-trying) unrelated files.
@@ -170,11 +175,18 @@ After a successful run you will see a summary like:
 
 ## Legacy: Single-File Generation (No DB)
 
-For quick one-off generation without touching the database:
+For quick one-off generation without touching the database, write a simple script:
 
-```bash
-python generate_audiobook.py input/audiobooks/some-article.txt
-python generate_audiobook.py input/audiobooks/some-article.txt --skip-llm
+```python
+from app.services.audiobook.pipeline import AudiobookService
+
+service = AudiobookService()
+with open("input/audiobooks/some-article.txt") as f:
+    text = f.read()
+
+# Outputs to outputs/audiobooks/some-article.mp3
+result = service.generate_from_text(text, skip_llm=True, title="some-article")
+print("Saved to:", result["audio_url"])
 ```
 
 This uses the `AudiobookService` wrapper which calls the audio pipeline directly and prints the output path. No playlist or episode records are created.

--- a/docs/audiobook-pipeline-how-to-run.md
+++ b/docs/audiobook-pipeline-how-to-run.md
@@ -1,0 +1,239 @@
+# Audiobook Pipeline — How to Run
+
+This guide covers everything you need to go from a `.txt` file to a playable audio episode in the database.
+
+---
+
+## Prerequisites
+
+### 1. System dependency — `ffmpeg`
+
+`pydub` (the audio stitching library) requires `ffmpeg` on the system `PATH`:
+
+```bash
+# Ubuntu / Debian
+sudo apt install ffmpeg
+
+# macOS
+brew install ffmpeg
+
+# Windows
+winget install Gyan.FFmpeg
+```
+
+### 2. Python dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Environment variables
+
+Copy the example and fill in your keys:
+
+```bash
+cp env.example .env
+```
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `DATABASE_URL` | ✅ Always | PostgreSQL connection string |
+| `OPENAI_API_KEY` | ✅ if LLM rewrite is on | GPT-4.1 for chapterization |
+| `DEEPGRAM_API_KEY` | ✅ if using Deepgram | TTS synthesis |
+| `SMALLEST_API_KEY` | ✅ if using Smallest AI | TTS synthesis |
+| `SUPABASE_URL` | Optional | Upload audio to Supabase Storage |
+| `SUPABASE_KEY` | Optional | Supabase service-role key |
+
+> **Note:** `OPENAI_API_KEY` is only needed if you run without `--skip-llm`. If you skip LLM, only the active TTS key is required.
+
+### 4. Database tables
+
+Ensure the `audio_playlists` and `audio_episodes` tables exist:
+
+```bash
+python scripts/migrate_schema.py
+```
+
+---
+
+## Preparing Input Files
+
+Place `.txt` files under `input/audiobooks/` (or a subdirectory — the pipeline accepts any directory path).
+
+### Single article
+
+```text
+---
+type: single_article
+title: "Bitcoin Mining Economics in 2025"
+author: "Lyn Alden"
+source_url: "https://example.com/article"
+tags: ["mining", "economics"]
+description: "A deep dive into mining profitability."
+---
+The actual article text goes here...
+```
+
+### Series (multi-part guide)
+
+Each episode is a **separate file**. Files are grouped by `series_slug` and ordered by `sequence_number`:
+
+```text
+---
+type: series
+series_slug: learn-me-a-bitcoin
+series_title: Learn Me a Bitcoin
+sequence_number: 3
+title: Mining and Proof of Work
+author: Greg Walker
+source_url: https://learnmeabitcoin.com/beginners/mining
+tags: ["bitcoin", "mining"]
+description: How Bitcoin mining works.
+---
+Mining is the process by which...
+```
+
+> **YAML gotcha:** If your `series_title` contains a colon (e.g. `"Learn Me a Bitcoin: Networking"`), wrap the whole value in quotes, otherwise YAML will reject it.
+
+### Plain text (no frontmatter)
+
+Files with no `---` block are automatically treated as a single article. The filename (minus extension, dashes/underscores replaced with spaces) becomes the title.
+
+---
+
+## Running the Pipeline
+
+### Full pipeline (recommended)
+
+```bash
+python curate_audiobooks.py
+```
+
+Reads all `.txt` files from `input/audiobooks/`, runs LLM chapterization on articles over 5,000 words, generates audio, and saves everything to the database.
+
+### Common flags
+
+```bash
+# Skip the OpenAI rewrite step (faster and cheaper)
+python curate_audiobooks.py --skip-llm
+
+# Point at a specific directory (avoids re-processing other files)
+python curate_audiobooks.py --input-dir input/audiobooks/networking
+
+# Override TTS provider
+python curate_audiobooks.py --provider smallest
+python curate_audiobooks.py --provider deepgram
+
+# Enable multi-speaker diarization
+python curate_audiobooks.py --diarize
+
+# Combine flags
+python curate_audiobooks.py --input-dir input/audiobooks/networking --skip-llm --provider smallest
+
+# Change the word count threshold for LLM chapterization (default: 5000)
+python curate_audiobooks.py --threshold 3000
+```
+
+> **Tip:** Use `--input-dir` to target a specific subfolder when you only want to process new files. This prevents the pipeline from re-scanning (and potentially re-trying) unrelated files.
+
+### Re-run safety
+
+The pipeline is **idempotent**. Episodes already in `completed` status are skipped automatically — no duplicate audio is generated. Episodes in `pending` or `failed` status will be re-attempted.
+
+---
+
+## Output
+
+After a successful run you will see a summary like:
+
+```
+============================================================
+  Results
+============================================================
+  Episodes generated : 9
+  Playlists touched  : 1
+  Errors             : 0
+
+  ✅ Pipeline completed successfully!
+```
+
+**Where the files go:**
+
+| Location | What |
+|---|---|
+| `outputs/audiobooks/<episode-id>/` | Per-episode MP3 and per-chapter MP3s |
+| `.cache/audiobooks/` | TTS chunk cache (keyed by provider + voice + text hash) — avoids re-synthesizing unchanged chunks |
+| Database `audio_episodes` | `audio_url`, `duration_seconds`, `chapters` JSON, `status = "completed"` |
+| Supabase Storage | Public URL (if `SUPABASE_URL` + `SUPABASE_KEY` are set) |
+
+---
+
+## Legacy: Single-File Generation (No DB)
+
+For quick one-off generation without touching the database:
+
+```bash
+python generate_audiobook.py input/audiobooks/some-article.txt
+python generate_audiobook.py input/audiobooks/some-article.txt --skip-llm
+```
+
+This uses the `AudiobookService` wrapper which calls the audio pipeline directly and prints the output path. No playlist or episode records are created.
+
+---
+
+## Programmatic Usage
+
+### Curate a directory
+
+```python
+from app.services.audiobook.curator import AudiobookCurator
+
+curator = AudiobookCurator(skip_llm=True, diarize=True)
+result = curator.curate_from_directory("input/audiobooks/networking")
+# {'episodes_generated': 9, 'playlists_touched': 1, 'errors': [], 'success': True}
+```
+
+### Curate a single text string
+
+```python
+curator = AudiobookCurator(skip_llm=True)
+result = curator.curate_single_text(
+    text="Bitcoin is a decentralized...",
+    title="Bitcoin Intro",
+    playlist_slug="bitcoin-basics",
+    playlist_title="Bitcoin Basics",
+    source_url="https://example.com",
+    tags=["bitcoin"],
+)
+print(result["episode"]["audio_url"])
+```
+
+### Raw audio generation (no DB writes)
+
+```python
+from app.services.audiobook.pipeline import AudioPipeline
+
+pipeline = AudioPipeline()
+episode = pipeline.generate_episode(
+    text="Your text here...",
+    title="My Episode",
+    skip_llm=True,
+    diarize=True,
+)
+print(f"Saved: {episode.audio_path}")
+print(f"Duration: {episode.duration_seconds}s")
+print(f"Chapters: {episode.chapters}")
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `mapping values are not allowed` YAML error | Wrap the field value containing `:` in double quotes |
+| `ffmpeg not found` | Install ffmpeg and ensure it's on your `PATH` |
+| `Database not configured` | Set `DATABASE_URL` in your `.env` |
+| TTS 401 / 403 errors | Check your `DEEPGRAM_API_KEY` or `SMALLEST_API_KEY` |
+| Episode stuck in `generating` | A previous run crashed mid-way. The next run will re-attempt it automatically |
+| `context canceled` in terminal | The run was interrupted. Re-run — completed episodes will be skipped |

--- a/docs/audiobook-pipeline-internals.md
+++ b/docs/audiobook-pipeline-internals.md
@@ -155,7 +155,7 @@ For each chapter:
 For each chunk:
 1. The `TTSProvider` instance handles pronunciation lexicons (currently via software fallback before API invocation).
 2. If diarization is active, the pipeline assigns a deterministic distinct voice based on a hash of the speaker's name.
-3. A cache key is computed from `provider + voice + format + text + lex_hash` (SHA-256, first 24 hex chars).
+3. A cache key is computed from `provider + voice + format + text + lex_hash + speed + model` (SHA-256, first 24 hex chars).
 4. If `.cache/audiobooks/<key>.mp3` exists → cache hit, reads bytes from disk.
 5. Otherwise → calls the TTS API, writes bytes to cache, returns bytes.
 
@@ -223,6 +223,11 @@ audio:
   silence_ms_between_chunks: 220
   silence_ms_between_chapters: 700
   target_dbfs: -20.0            # loudness normalization target
+
+paths:
+  output_dir: outputs/audiobooks
+  cache_dir: .cache/audiobooks
+  lexicon: audiobook_lexicon.json
 ```
 
 **`app/services/audiobook_lexicon.json`**

--- a/docs/audiobook-pipeline-internals.md
+++ b/docs/audiobook-pipeline-internals.md
@@ -1,0 +1,255 @@
+# Audiobook Pipeline — Architecture & Step-by-Step Internals
+
+This document explains what happens inside the pipeline from the moment you run `python curate_audiobooks.py` to the moment a playable audio URL lands in the database.
+
+---
+
+## High-Level Data Flow
+
+```
+.txt files (input/)
+        │
+        ▼
+  [1] INGESTION           ingestion.py
+  Parse YAML frontmatter
+  Return InputFile objects
+        │
+        ├─── series files ──────────────────────┐
+        │                                       │
+        └─── single articles ─────┐             │
+                                  ▼             ▼
+                          [2] CURATOR          curator.py
+                          Route: single vs. series
+                          Call pipeline per episode
+                          Call playlist_service for DB writes
+                                  │
+                                  ▼
+                          [3] PIPELINE         pipeline.py
+                          clean → rewrite → TTS → stitch
+                                  │
+                    ┌─────────────┼─────────────┐
+                    ▼             ▼             ▼
+              [3a] textproc  [3b] rewrite   [3c] tts
+              clean_text()   OpenAI LLM    Deepgram /
+              normalize()    chapterize    Smallest AI
+              chunk_split()
+                                  │
+                                  ▼
+                          [3d] STITCH          stitch.py
+                          pydub concatenation
+                          silence gaps + loudness normalize
+                                  │
+                                  ▼
+                          [4] STORAGE          storage.py
+                          Upload MP3 → Supabase (optional)
+                          Returns public URL
+                                  │
+                                  ▼
+                          [5] DATABASE         playlist_service.py
+                          Update audio_episodes:
+                          audio_url, duration, chapters, status
+```
+
+---
+
+## Module Responsibilities
+
+| Module | File | What it does |
+|---|---|---|
+| **Ingestion** | `ingestion.py` | Scans input directory, parses YAML frontmatter, returns `InputFile` dataclass objects. Groups series files by `series_slug`. |
+| **Curator** | `curator.py` | The orchestrator. Routes singles vs. series. Calls the pipeline for each episode and writes results to DB via `PlaylistService`. |
+| **Pipeline** | `pipeline.py` | Stateless audio engine. Takes raw text in, produces a `GeneratedEpisode` (path + duration + chapters) out. Does **not** write to DB. |
+| **Text Processing** | `textproc.py` | Advanced text cleaning (preserves speakers if `retain_speakers=True`), `num2words`-based number/date expansion, acronym handling, NLTK-based semantic chunking, and diarization parsing. |
+| **Rewrite** | `rewrite.py` | Sends text to OpenAI GPT-4.1. Returns a chapterized narration script as JSON. |
+| **TTS** | `tts.py` | Abstract `TTSProvider` with `DeepgramTTS` and `SmallestTTS` implementations. Injects pronunciation lexicons natively into the generation logic. |
+| **Stitch** | `stitch.py` | Uses `pydub` to concatenate audio chunks, insert silence gaps between chunks and chapters, and normalize loudness. |
+| **Storage** | `storage.py` | Uploads the final MP3 to Supabase Storage via REST API. Returns the public URL (or `None` if unconfigured). |
+| **Playlist Service** | `playlist_service.py` | All DB CRUD. `find_or_create_playlist()`, `find_or_create_episode()`, `update_episode()`, `refresh_playlist_stats()`. |
+| **Config** | `config.py` | Loads `audiobook_config.yaml` + `audiobook_lexicon.json`. Injects API keys from env. Returns `(cfg, lexicon)` tuple. |
+
+---
+
+## Step-by-Step Pipeline Internals
+
+### Step 1 — Ingestion (`ingestion.py`)
+
+`scan_input_directory(path)` globs all `*.txt` files and calls `parse_file()` on each.
+
+`parse_file()` does the following:
+1. Reads the raw file text.
+2. Applies a regex (`^---\n...\n---\n`) to detect YAML frontmatter.
+3. If no frontmatter is found → treated as `single_article`; filename becomes the title.
+4. If frontmatter is found → `yaml.safe_load()` parses the metadata block.
+5. Returns an `InputFile` dataclass with fields: `filepath`, `input_type`, `title`, `body`, `series_slug`, `sequence_number`, `author`, `source_url`, `description`, `tags`.
+
+`group_series()` separates series files from singles and groups them by `series_slug`, sorted by `sequence_number`.
+
+---
+
+### Step 2 — Curator routes the work (`curator.py`)
+
+`curate_from_directory()` calls ingestion, then:
+
+- **Series group** → `_process_series(slug, files)`
+  - Calls `find_or_create_playlist()` with `playlist_type="series"`.
+  - Iterates over files in sequence order.
+  - For each file: calls `find_or_create_episode()`, then `_generate_and_update()` with `skip_llm=True` (series episodes are already logically divided — no LLM chapterization needed).
+
+- **Single article** → `_process_single_article(inp)`
+  - Calls `find_or_create_playlist()` with `playlist_type="collection"`.
+  - Creates one episode.
+  - Calls `_generate_and_update()` with `skip_llm=True` if the word count is below the threshold (default: 5,000 words), bypassing LLM chapterization for short articles.
+
+`_generate_and_update()` is the bridge between curator and pipeline:
+1. Checks episode status — skips if `completed`.
+2. Sets status to `generating` in DB.
+3. Calls `pipeline.generate_episode()`.
+4. Optionally uploads to Supabase via `upload_to_supabase()`.
+5. Updates the episode record with `audio_url`, `duration_seconds`, `chapters`, and `status = "completed"`.
+6. On failure: sets `status = "failed"` and re-raises.
+
+---
+
+### Step 3 — Audio Pipeline (`pipeline.py`)
+
+`AudioPipeline.generate_episode(text, title, skip_llm, ...)` runs these stages in order:
+
+#### 3a — Text Cleaning (`textproc.clean_text`)
+
+Strips content that doesn't read well aloud:
+- Timestamps like `[00:12:45]` or `(1:30)`
+- Speaker labels like `ALICE: ` or `Host: ` (unless `diarize=True` / `retain_speakers=True` is passed)
+- Stage directions like `[laughter]`, `(applause)`
+- Collapses excess whitespace and blank lines
+
+#### 3b — LLM Rewrite / Chapterization (`rewrite.rewrite`)
+
+Skipped if `skip_llm=True` (either via `--skip-llm` flag, or because the article is short enough).
+
+When active:
+1. Sends the cleaned text to OpenAI GPT-4.1 with a system prompt instructing it to act as an audiobook editor.
+2. The model returns structured JSON:
+   ```json
+   {
+     "title": "Episode Title",
+     "chapters": [
+       {"title": "Chapter 1 Title", "text": "Narration text..."},
+       {"title": "Chapter 2 Title", "text": "Narration text..."}
+     ]
+   }
+   ```
+3. The caller's title always overrides the LLM-generated title (to preserve consistency with the DB record).
+
+When skipped, a single-chapter manifest is built directly from the cleaned text.
+
+#### 3c — Normalization, Diarization, + Chunking (`textproc.py`)
+
+For each chapter:
+
+1. **Diarization (`parse_diarization`)** — If `diarize=True`, parses speaker labels into chunks mapping speakers to their dialogue. Otherwise, treats the text as a single default chunk.
+2. **`normalize(text)`** — Expands monetary values, uses `num2words` for robust year/date/ordinal expansion, and safely hyphens unpronounceable acronyms (e.g., `AWS` → `A-W-S`).
+3. **`chunk_split(text, max_chars)`** — Splits text into TTS-safe chunks using NLTK (`sent_tokenize`). If a sentence exceeds the limit, it performs prosody-aware splitting at natural boundaries (commas, semicolons, em-dashes).
+
+#### 3d — TTS Synthesis (`tts.synthesize` + cache)
+
+For each chunk:
+1. The `TTSProvider` instance handles pronunciation lexicons (currently via software fallback before API invocation).
+2. If diarization is active, the pipeline assigns a deterministic distinct voice based on a hash of the speaker's name.
+3. A cache key is computed from `provider + voice + format + text + lex_hash` (SHA-256, first 24 hex chars).
+4. If `.cache/audiobooks/<key>.mp3` exists → cache hit, reads bytes from disk.
+5. Otherwise → calls the TTS API, writes bytes to cache, returns bytes.
+
+This cache means re-running the pipeline after a crash is fast — only uncached chunks hit the network. Updates to the `audiobook_lexicon.json` will also correctly invalidate the cache.
+
+#### 3e — Stitching (`stitch.py`)
+
+1. **`build_chapter(chunks, cfg)`** — Converts each raw-bytes chunk into a `pydub.AudioSegment`. Concatenates them with a configurable silence gap (default: 220ms) between chunks.
+2. **`export_segment(seg, path)`** — Saves the chapter audio to disk as `outputs/audiobooks/<episode-id>/ch01.mp3`, `ch02.mp3`, etc.
+3. **`export_book(chapters, cfg, out_path)`** — Concatenates all chapter segments with a larger silence gap (default: 700ms) between chapters. Runs `normalize_loudness()` targeting −20 dBFS. Saves the final file as `outputs/audiobooks/<episode-id>/<Episode Title>.mp3`.
+
+---
+
+### Step 4 — Supabase Upload (`storage.py`)
+
+If `SUPABASE_URL` and `SUPABASE_KEY` are set:
+- POSTs the MP3 file to `<SUPABASE_URL>/storage/v1/object/audiobooks/<Safe Playlist Title>/<Safe Episode Title>.mp3` (with special characters and slashes removed to prevent path traversal).
+- If a duplicate is detected (HTTP 400), retries with PUT to overwrite.
+- Returns the public URL on success; returns `None` and logs a warning on failure.
+
+The curator uses the public URL as `audio_url` if the upload succeeded, otherwise falls back to the local absolute path.
+
+---
+
+### Step 5 — Database Persistence (`playlist_service.py`)
+
+All DB operations use SQLAlchemy sessions via `get_session()` context manager.
+
+Key methods:
+
+| Method | What it does |
+|---|---|
+| `find_or_create_playlist(slug, title, ...)` | Upsert by slug. Returns existing playlist or creates a new one in `draft` status. |
+| `find_or_create_episode(playlist_id, title, seq_num, ...)` | Upsert by `(playlist_id, sequence_number)`. Returns existing or creates new in `pending` status. |
+| `update_episode(episode_id, updates)` | Sets arbitrary fields (status, audio_url, duration_seconds, chapters, etc.). |
+| `refresh_playlist_stats(playlist_id)` | Recomputes `episode_count` and `total_duration_seconds` from all `completed` episodes and writes them to the playlist row. |
+
+---
+
+## Configuration Reference
+
+**`app/services/audiobook_config.yaml`**
+
+```yaml
+llm:
+  provider: openai
+  model: gpt-4.1
+  temperature: 0.3
+  max_words_per_request: 2500   # split long input before sending to LLM
+
+tts:
+  provider: deepgram            # deepgram | smallest
+  voices:
+    deepgram: aura-2-thalia-en
+    smallest: meher
+  models:
+    smallest: lightning_v3.1_pro
+  max_chars:
+    deepgram: 1900              # per-request character cap
+    smallest: 240
+  speed: 1.0
+  format: mp3
+
+audio:
+  silence_ms_between_chunks: 220
+  silence_ms_between_chapters: 700
+  target_dbfs: -20.0            # loudness normalization target
+```
+
+**`app/services/audiobook_lexicon.json`**
+
+A flat JSON object mapping terms to their spoken equivalents:
+
+```json
+{
+  "_comment": "Key = term to match (case-insensitive), Value = replacement",
+  "UTXO": "you-tee-ex-oh",
+  "BIP": "bitcoin improvement proposal",
+  "DeFi": "dee-fye"
+}
+```
+
+Keys starting with `_` are ignored (used for comments).
+
+---
+
+## Idempotency & Re-run Safety
+
+The pipeline is designed to be safely re-run at any time:
+
+- **Playlist** → matched by `slug`. If it exists, it is reused — never duplicated.
+- **Episode** → matched by `(playlist_id, sequence_number)`. If it exists, it is reused.
+- **`completed` episodes** → skipped in `_generate_and_update`. No TTS calls made.
+- **`pending` / `failed` episodes** → re-attempted.
+- **TTS cache** → chunk bytes cached by content hash. Unchanged text costs zero API calls.
+
+This means you can safely run `python curate_audiobooks.py` multiple times and only genuinely new or failed work will be processed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ PyYAML==6.0.1
 librosa==0.10.2.post1
 fastapi==0.111.0
 uvicorn>=0.30.0
-PyJWT==2.9.0
+PyJWT>=2.13.0
 cryptography==43.0.1
 psutil==7.0.0
 openai==1.98.0
@@ -27,3 +27,7 @@ psycopg2-binary>=2.9.0
 google-genai>=0.8.0
 google-generativeai>=0.3.2
 google-api-python-client>=2.100.0
+pydub>=0.25
+audioop-lts>=0.2; python_version >= '3.13'
+num2words>=0.5.13
+nltk>=3.9.4

--- a/scripts/add_indexes.py
+++ b/scripts/add_indexes.py
@@ -80,6 +80,16 @@ def add_indexes():
                 )
         else:
             logger.info('Skipping optional PostgreSQL extension creation for "pg_trgm".')
+            
+        try:
+            invalid_indexes = conn.execute(text(
+                "SELECT i.relname FROM pg_class i JOIN pg_index x ON i.oid = x.indexrelid WHERE x.indisvalid = false;"
+            )).scalars().all()
+            for idx in invalid_indexes:
+                logger.info(f"Dropping invalid index: {idx}")
+                conn.execute(text(f"DROP INDEX CONCURRENTLY IF EXISTS {idx};"))
+        except Exception as e:
+            logger.warning(f"Could not check/drop invalid indexes: {e}")
         
         for sql in index_sqls:
             logger.info(f"Executing: {sql.strip().split(chr(10))[0]}...")

--- a/scripts/migrate_schema.py
+++ b/scripts/migrate_schema.py
@@ -83,6 +83,10 @@ def run_migration(dry_run=False):
             if not dry_run:
                 logger.info("Creating new tables...")
                 Base.metadata.create_all(conn)
+                
+                # Ensure unique constraint exists if table already existed
+                conn.execute(text("ALTER TABLE transcripts DROP CONSTRAINT IF EXISTS uq_transcripts_content_item_version;"))
+                conn.execute(text("ALTER TABLE transcripts ADD CONSTRAINT uq_transcripts_content_item_version UNIQUE (content_item_id, version);"))
             else:
                 logger.info("DRY RUN: Base.metadata.create_all(conn)")
 
@@ -145,29 +149,36 @@ def run_migration(dry_run=False):
 
             logger.info("Migrating data from old_youtube_videos -> content_items...")
             migrate_items_sql = """
+                WITH deduped_channels AS (
+                    SELECT id AS old_id,
+                           CASE WHEN COUNT(*) OVER (PARTITION BY LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g'))) > 1 THEN LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g')) || '-' || id ELSE LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g')) END AS slug
+                    FROM old_youtube_channels
+                )
                 INSERT INTO content_items (id, source_id, external_id, title, description, content_type, url, published_at, event_date, status, technical_score, source_metadata, discovered_at)
                 SELECT 
-                    id, 
-                    channel_id, 
-                    video_id, 
-                    title, 
-                    description, 
+                    v.id, 
+                    cs.id, 
+                    v.video_id, 
+                    v.title, 
+                    v.description, 
                     'video', 
-                    'https://www.youtube.com/watch?v=' || video_id, 
-                    published_at, 
+                    'https://www.youtube.com/watch?v=' || v.video_id, 
+                    v.published_at, 
                     NULL, 
-                    status, 
-                    CASE WHEN is_technical THEN 5 ELSE 1 END, 
+                    v.status, 
+                    CASE WHEN v.is_technical THEN 5 ELSE 1 END, 
                     jsonb_build_object(
-                        'duration', duration, 
-                        'tags', tags, 
-                        'thumbnail_url', thumbnail_url, 
-                        'view_count', view_count,
-                        'classification_reason', classification_reason,
-                        'classification_confidence', classification_confidence
+                        'duration', v.duration, 
+                        'tags', v.tags, 
+                        'thumbnail_url', v.thumbnail_url, 
+                        'view_count', v.view_count,
+                        'classification_reason', v.classification_reason,
+                        'classification_confidence', v.classification_confidence
                     ), 
-                    discovered_at
-                FROM old_youtube_videos;
+                    v.discovered_at
+                FROM old_youtube_videos v
+                JOIN deduped_channels dc ON v.channel_id = dc.old_id
+                JOIN content_sources cs ON cs.slug = dc.slug;
             """
             if not dry_run:
                 res = conn.execute(text(migrate_items_sql))
@@ -288,7 +299,7 @@ def run_migration(dry_run=False):
                         last_run_status = pr.status
                     FROM (
                         SELECT id, source_id, status,
-                               ROW_NUMBER() OVER(PARTITION BY source_id ORDER BY started_at DESC) as rn
+                               ROW_NUMBER() OVER(PARTITION BY source_id ORDER BY started_at DESC NULLS LAST, id ASC) as rn
                         FROM pipeline_runs
                         WHERE source_id IS NOT NULL
                     ) pr


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an end-to-end audiobook pipeline with a curator that ingests YAML-annotated .txt files, generates TTS audio (optional LLM chapterization and diarized voices), stitches/normalizes, uploads, and persists playlists/episodes with caching and resume safety.

- **New Features**
  - Orchestration: `curator` routes singles vs. series, applies a chapterize threshold (default 5,000 words), supports `skip_llm`, `provider_override`, and `diarize`. Ingestion parses YAML frontmatter (single_article or series) and groups by `series_slug`/`sequence_number`.
  - Audio engine: `pipeline` cleans text, optionally rewrites with OpenAI, splits smartly, applies lexicon, and synthesizes via Deepgram or Smallest. Cache key now includes lexicon/speed/model; per-chapter files are exported and stitched with silence and loudness normalization. Output and cache default to `outputs/audiobooks` and `.cache/audiobooks`. TTS formats limited to `mp3`/`wav`.
  - Storage: optional Supabase upload with configurable timeout and deterministic path `audiobooks/<Playlist_Title>/<Episode_Title>.<ext>`; falls back to local path.
  - Database: new `AudioPlaylist` and `AudioEpisode` models with indexes; `PlaylistService` for CRUD and playlist stat refresh. Idempotent: completed episodes are skipped; failed/pending are retried.
  - Service/robustness: fixes empty-chapter handling in rewrite, safer audio concatenation, acronym pluralization and chunk size validation in textproc, classifier `category` fallback, external-id dedupe across all sources, and dropping invalid indexes before (re)creating. Docs added: how-to-run and internals. `audiobook_service.py` provides a simple entry point.

- **Migration**
  - Run schema and indexing: `python scripts/migrate_schema.py` (ensures transcript uniqueness on content_item+version) then `python scripts/add_indexes.py` (drops invalid indexes and adds new ones).
  - Install deps and tools: `pip install -r requirements.txt` (adds `pydub`, `audioop-lts` for py3.13+, `num2words`, `nltk`; bumps `PyJWT` to `>=2.13.0`) and ensure `ffmpeg` is on PATH.
  - Set env vars as needed: `DATABASE_URL`, `OPENAI_API_KEY` (if not skipping LLM), `DEEPGRAM_API_KEY` or `SMALLEST_API_KEY`, and optionally `SUPABASE_URL`/`SUPABASE_KEY`/`SUPABASE_UPLOAD_TIMEOUT` for uploads.

<sup>Written for commit bd7d030f6960e6eeff54891a28d2429e7c523946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/genesis-kb/transcription_engine/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

