### PR TITLE
Pr/audiobook 4 api docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ logs/
 metadata/
 scripts/
 .github/.DS_Store
+input/audiobooks/

--- a/app/services/audiobook/README.md
+++ b/app/services/audiobook/README.md
@@ -16,6 +16,7 @@ app/services/audiobook/
 ├── textproc.py           # Text cleaning, normalization, chunking
 ├── tts.py                # TTS providers (Deepgram, Smallest AI)
 ├── stitch.py             # Audio stitching + loudness normalization
+├── storage.py            # Supabase audio uploading
 └── README.md             # This file
 ```
 
@@ -31,6 +32,7 @@ app/services/audiobook/
 | **`textproc.py`** | Regex-based text cleaning (strips timestamps, speaker tags), lexicon substitution, sentence-boundary chunking. |
 | **`tts.py`** | Abstract `TTSProvider` with implementations for Deepgram and Smallest AI. |
 | **`stitch.py`** | Uses `pydub` to concatenate audio chunks, insert silence gaps, and normalize loudness. |
+| **`storage.py`** | Uploads generated MP3 files to Supabase object storage. |
 
 ## 🚀 How to Run (Step-by-Step)
 
@@ -45,6 +47,8 @@ Ensure your `.env` file in the project root has these keys:
 OPENAI_API_KEY=your_openai_key
 DEEPGRAM_API_KEY=your_deepgram_key
 SMALLEST_API_KEY=your_smallest_key
+SUPABASE_URL=your_supabase_url
+SUPABASE_KEY=your_supabase_key
 ```
 
 **Step 3: Run Database Migration**
@@ -157,6 +161,8 @@ Loaded automatically from the project root `.env`:
 OPENAI_API_KEY=      # LLM rewrite (only needed if NOT using --skip-llm)
 DEEPGRAM_API_KEY=    # Deepgram TTS provider
 SMALLEST_API_KEY=    # Smallest AI TTS provider
+SUPABASE_URL=        # Supabase API URL for storage
+SUPABASE_KEY=        # Supabase API Key for storage
 ```
 
 ## 🛠️ System Requirements

--- a/app/services/audiobook/curator.py
+++ b/app/services/audiobook/curator.py
@@ -229,7 +229,7 @@ class AudiobookCurator:
             tags=inp.tags,
         )
 
-        seq = self._playlists.get_next_sequence_number(playlist["id"])
+        seq = 1
         episode, created = self._playlists.find_or_create_episode(
             playlist_id=playlist["id"],
             title=inp.title,

--- a/app/services/audiobook/ingestion.py
+++ b/app/services/audiobook/ingestion.py
@@ -119,6 +119,10 @@ def parse_file(filepath: Path) -> Optional[InputFile]:
         return None
         
     title = meta.get("title", filepath.stem.replace("_", " ").title())
+    
+    if input_type not in ("single_article", "series"):
+        logger.warning(f"Invalid type '{input_type}' in {filepath.name}, defaulting to single_article")
+        input_type = "single_article"
 
     if input_type == "series":
         if not meta.get("series_slug"):

--- a/app/services/audiobook/pipeline.py
+++ b/app/services/audiobook/pipeline.py
@@ -249,5 +249,5 @@ class AudiobookService:
                 "status": "completed",
             }
         except Exception as e:
-            logger.error(f"Audio generation failed: {e}")
+            logger.exception(f"Audio generation failed: {e}")
             return None

--- a/app/services/audiobook/playlist_service.py
+++ b/app/services/audiobook/playlist_service.py
@@ -136,8 +136,9 @@ class PlaylistService:
             )
             if not pl:
                 return None
+            ALLOWED_PLAYLIST_FIELDS = {"title", "slug", "playlist_type", "description", "tags", "status", "cover_image_url"}
             for key, value in updates.items():
-                if hasattr(pl, key):
+                if key in ALLOWED_PLAYLIST_FIELDS and hasattr(pl, key):
                     setattr(pl, key, value)
             pl.updated_at = datetime.now(timezone.utc)
             session.commit()
@@ -289,10 +290,11 @@ class PlaylistService:
             )
             if not ep:
                 return None
+            ALLOWED_EPISODE_FIELDS = {"title", "description", "sequence_number", "audio_url", "duration_seconds", "source_url", "status", "chapters"}
             for key, value in updates.items():
                 if key == "metadata":
                     ep.metadata_ = value
-                elif hasattr(ep, key):
+                elif key in ALLOWED_EPISODE_FIELDS and hasattr(ep, key):
                     setattr(ep, key, value)
             session.commit()
             return ep.to_dict()

--- a/app/services/audiobook/rewrite.py
+++ b/app/services/audiobook/rewrite.py
@@ -24,49 +24,64 @@ SOURCE:
 \"\"\""""
 
 def rewrite(text: str, cfg: dict[str, Any]) -> dict[str, Any]:
-    client = OpenAI(api_key=cfg["keys"].get("openai", ""))
-    resp = client.chat.completions.create(
-        model=cfg["llm"]["model"],
-        temperature=cfg["llm"]["temperature"],
-        response_format={"type": "json_object"},
-        messages=[
-            {"role": "system", "content": SYSTEM},
-            {"role": "user", "content": USER_TMPL.format(source=text)},
-        ],
-    )
-    try:
-        content = resp.choices[0].message.content
-        if not content:
-            manifest = {}
-        else:
-            manifest = json.loads(content)
-            if not isinstance(manifest, dict):
-                manifest = {}
-    except (IndexError, AttributeError, ValueError, json.JSONDecodeError):
-        manifest = {}
-
-    manifest.setdefault("title", "Untitled Audiobook")
+    max_words = cfg["llm"].get("max_words_per_request", 3000)
+    words = text.split()
     
-    chapters = manifest.get("chapters", [])
-    if not isinstance(chapters, list):
-        chapters = []
-        
-    valid_chapters = []
-    for ch in chapters:
-        if not isinstance(ch, dict):
-            continue
-        title = ch.get("title")
-        text_val = ch.get("text")
-        # Coerce non-string values; skip entries that are None or non-stringable
-        if title is None or text_val is None:
-            continue
-        if not isinstance(title, str):
-            title = str(title)
-        if not isinstance(text_val, str):
-            text_val = str(text_val)
-        if not title.strip() or not text_val.strip():
-            continue
-        valid_chapters.append({"title": title.strip(), "text": text_val})
+    if len(words) <= max_words:
+        chunks = [text]
+    else:
+        chunks = []
+        for i in range(0, len(words), max_words):
+            chunks.append(" ".join(words[i:i + max_words]))
             
-    manifest["chapters"] = valid_chapters
-    return manifest
+    client = OpenAI(api_key=cfg["keys"].get("openai", ""))
+    
+    merged_chapters = []
+    book_title = "Untitled Audiobook"
+    
+    for chunk in chunks:
+        resp = client.chat.completions.create(
+            model=cfg["llm"]["model"],
+            temperature=cfg["llm"]["temperature"],
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": SYSTEM},
+                {"role": "user", "content": USER_TMPL.format(source=chunk)},
+            ],
+        )
+        try:
+            content = resp.choices[0].message.content
+            if not content:
+                manifest = {}
+            else:
+                manifest = json.loads(content)
+                if not isinstance(manifest, dict):
+                    manifest = {}
+        except (IndexError, AttributeError, ValueError, json.JSONDecodeError):
+            manifest = {}
+
+        if manifest.get("title") and book_title == "Untitled Audiobook":
+            if isinstance(manifest["title"], str) and manifest["title"].strip():
+                book_title = manifest["title"].strip()
+        
+        chapters = manifest.get("chapters", [])
+        if not isinstance(chapters, list):
+            chapters = []
+            
+        for ch in chapters:
+            if not isinstance(ch, dict):
+                continue
+            title = ch.get("title")
+            text_val = ch.get("text")
+            # Coerce non-string values; skip entries that are None or non-stringable
+            if title is None or text_val is None:
+                continue
+            if not isinstance(title, str):
+                title = str(title)
+            if not isinstance(text_val, str):
+                text_val = str(text_val)
+            if not title.strip() or not text_val.strip():
+                continue
+            merged_chapters.append({"title": title.strip(), "text": text_val.strip()})
+            
+    return {"title": book_title, "chapters": merged_chapters}

--- a/app/services/audiobook/stitch.py
+++ b/app/services/audiobook/stitch.py
@@ -21,7 +21,9 @@ def build_chapter(chunks: list[bytes], cfg: dict[str, Any]) -> AudioSegment:
     segments = [first]
     for c in chunks[1:]:
         segments.append(gap)
-        segments.append(_seg(c, fmt))
+        seg = _seg(c, fmt)
+        seg = seg.set_frame_rate(first.frame_rate).set_channels(first.channels).set_sample_width(first.sample_width)
+        segments.append(seg)
         
     res = segments[0]
     for s in segments[1:]:
@@ -51,6 +53,7 @@ def export_book(chapters: list[AudioSegment], cfg: dict[str, Any], out_path: Pat
     segments = [first]
     for ch in chapters[1:]:
         segments.append(gap)
+        ch = ch.set_frame_rate(first.frame_rate).set_channels(first.channels).set_sample_width(first.sample_width)
         segments.append(ch)
         
     book = segments[0]

--- a/app/services/audiobook/storage.py
+++ b/app/services/audiobook/storage.py
@@ -17,7 +17,9 @@ def upload_to_supabase(file_path: Path, bucket_name: str, destination_path: str)
         logger.warning("SUPABASE_URL or SUPABASE_KEY not set. Cannot upload to Supabase.")
         return None
         
-    safe_destination = urllib.parse.quote(destination_path)
+    segments = [urllib.parse.quote(p) for p in destination_path.split("/") if p and p not in (".", "..")]
+    safe_destination = "/".join(segments)
+    
     url = f"{supabase_url.rstrip('/')}/storage/v1/object/{bucket_name}/{safe_destination}"
     mime_type, _ = mimetypes.guess_type(str(file_path))
     

--- a/app/services/audiobook/textproc.py
+++ b/app/services/audiobook/textproc.py
@@ -5,8 +5,8 @@ try:
 except ImportError:
     num2words = None
 
-TIMESTAMP = re.compile(r"[\[\(]?\b\d{1,2}:\d{2}(?::\d{2})?\b[\]\)]?")
-SPEAKER = re.compile(r"^\s*[A-Z][A-Za-z0-9 _-]{0,30}:\s", re.MULTILINE)
+TIMESTAMP = re.compile(r"[\[\(]\b\d{1,2}:\d{2}(?::\d{2})?\b[\]\)]|^\s*\d{1,2}:\d{2}(?::\d{2})?\b", re.MULTILINE)
+SPEAKER = re.compile(r"^\s*(?!(?:Chapter|Question|Answer|Note|Part|Section)\b)[A-Z][A-Za-z0-9 _-]{0,30}:\s", re.MULTILINE)
 STAGE = re.compile(r"[\[\(](?:laughter|music|applause|crosstalk|inaudible)[\]\)]", re.I)
 MULTISPACE = re.compile(r"[ \t]{2,}")
 MULTINEWLINE = re.compile(r"\n{3,}")

--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -63,42 +63,35 @@ class DatabaseService:
                     if hasattr(source, "loc") and source.loc:
                         content_source = session.query(ContentSource).filter_by(slug=source.loc).first()
                         
-                    content_item = None
-                    if video_id:
-                        query = session.query(ContentItem).filter_by(external_id=video_id)
-                        content_item = query.first()
+                    if content_source:
+                        target_source_id = content_source.id
+                    else:
+                        manual_source = session.query(ContentSource).filter_by(slug='manual-imports').first()
+                        if not manual_source:
+                            manual_source = ContentSource(
+                                name='Manual Imports',
+                                slug='manual-imports',
+                                source_type='manual',
+                                is_active=True
+                            )
+                            session.add(manual_source)
+                            session.flush()
+                        target_source_id = manual_source.id
+                        
+                    ext_id = video_id if video_id else f"manual-{uuid.uuid4().hex[:12]}"
+                    content_item = session.query(ContentItem).filter_by(source_id=target_source_id, external_id=ext_id).first()
                     
                     if not content_item:
-                        if content_source:
-                            target_source_id = content_source.id
-                        else:
-                            # Find or create manual source
-                            manual_source = session.query(ContentSource).filter_by(slug='manual-imports').first()
-                            if not manual_source:
-                                manual_source = ContentSource(
-                                    name='Manual Imports',
-                                    slug='manual-imports',
-                                    source_type='manual',
-                                    is_active=True
-                                )
-                                session.add(manual_source)
-                                session.flush()
-                            target_source_id = manual_source.id
-
-                        ext_id = video_id if video_id else f"manual-{uuid.uuid4().hex[:12]}"
-                        
-                        content_item = session.query(ContentItem).filter_by(source_id=target_source_id, external_id=ext_id).first()
-                        if not content_item:
-                            content_item = ContentItem(
-                                source_id=target_source_id,
-                                external_id=ext_id,
-                                title=source.title or 'Unknown',
-                                content_type='video',
-                                url=media_url,
-                                status='transcribed'
-                            )
-                            session.add(content_item)
-                            session.flush()
+                        content_item = ContentItem(
+                            source_id=target_source_id,
+                            external_id=ext_id,
+                            title=source.title or 'Unknown',
+                            content_type='video',
+                            url=media_url,
+                            status='transcribed'
+                        )
+                        session.add(content_item)
+                        session.flush()
                     else:
                         content_item.status = 'transcribed'
 
@@ -138,6 +131,8 @@ class DatabaseService:
                         from app.utils import slugify
                         for spk_name in source.speakers:
                             spk_slug = slugify(spk_name)
+                            if not spk_slug:
+                                spk_slug = f"unknown-{uuid.uuid4().hex[:8]}"
                             spk = session.query(Speaker).filter_by(slug=spk_slug).first()
                             if not spk:
                                 spk = Speaker(name=spk_name, slug=spk_slug)

--- a/curate_audiobooks.py
+++ b/curate_audiobooks.py
@@ -14,7 +14,6 @@ Usage:
     python curate_audiobooks.py --provider smallest
 """
 import argparse
-import json
 import sys
 
 from app.services.audiobook.curator import AudiobookCurator

--- a/curate_audiobooks.py
+++ b/curate_audiobooks.py
@@ -1,0 +1,96 @@
+"""CLI entry point for the audiobook curation pipeline.
+
+Usage:
+    # Process all files in input/audiobooks/
+    python curate_audiobooks.py
+
+    # Process files in a custom directory
+    python curate_audiobooks.py --input-dir path/to/files
+
+    # Skip the LLM rewrite step (faster, cheaper)
+    python curate_audiobooks.py --skip-llm
+
+    # Use a specific TTS provider
+    python curate_audiobooks.py --provider smallest
+"""
+import argparse
+import json
+import sys
+
+from app.services.audiobook.curator import AudiobookCurator
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Curate audiobook playlists from text files."
+    )
+    parser.add_argument(
+        "--input-dir",
+        default="input/audiobooks",
+        help="Directory containing .txt files (default: input/audiobooks)",
+    )
+    parser.add_argument(
+        "--skip-llm",
+        action="store_true",
+        help="Skip the OpenAI LLM rewrite/chapterization step",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["deepgram", "smallest"],
+        default=None,
+        help="Override the TTS provider from config",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=5000,
+        help="Word count above which single articles are chapterized "
+             "via LLM (default: 5000)",
+    )
+    parser.add_argument(
+        "--diarize",
+        action="store_true",
+        help="Enable dynamic multi-speaker diarization",
+    )
+    args = parser.parse_args()
+
+    print(f"{'='*60}")
+    print(f"  Audiobook Curation Pipeline")
+    print(f"{'='*60}")
+    print(f"  Input dir  : {args.input_dir}")
+    print(f"  Skip LLM   : {args.skip_llm}")
+    print(f"  Diarize    : {args.diarize}")
+    print(f"  TTS provider: {args.provider or '(from config)'}")
+    print(f"  Chapterize threshold: {args.threshold} words")
+    print(f"{'='*60}\n")
+
+    curator = AudiobookCurator(
+        chapterize_threshold=args.threshold,
+        skip_llm=args.skip_llm,
+        provider_override=args.provider,
+        diarize=args.diarize,
+    )
+
+    result = curator.curate_from_directory(args.input_dir)
+
+    print(f"\n{'='*60}")
+    print(f"  Results")
+    print(f"{'='*60}")
+    print(f"  Episodes generated : {result['episodes_generated']}")
+    print(f"  Playlists touched  : {result['playlists_touched']}")
+    print(f"  Errors             : {len(result['errors'])}")
+
+    if result["errors"]:
+        print(f"\n  Errors:")
+        for err in result["errors"]:
+            print(f"    ✗ {err}")
+
+    if result["success"]:
+        print(f"\n  ✅ Pipeline completed successfully!")
+    else:
+        print(f"\n  ⚠️  Pipeline completed with errors")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/Ingestion_API_Endpoints.md
+++ b/docs/Ingestion_API_Endpoints.md
@@ -2,7 +2,7 @@
 
 **Base URL**: `http://localhost:8000`
 
-All endpoints are prefixed by their respective router. The four routers and their prefixes are:
+All endpoints are prefixed by their respective router. The five routers and their prefixes are:
 
 | Router | Prefix |
 |---|---|
@@ -10,6 +10,7 @@ All endpoints are prefixed by their respective router. The four routers and thei
 | Transcription | `/transcription` |
 | Curator | `/curator` |
 | Media | `/media` |
+| Audiobooks | `/audiobooks` |
 
 ---
 
@@ -160,8 +161,10 @@ Adds a **new** content source to monitor.
   ```
 - **Required Fields**: `name`, `slug`
 - **Optional Fields**: `source_type` (default: `youtube`), `base_url`, `config`, `is_active` (default: `true`)
-- **Success Response** (`200`): The created `ContentSource` object.
-- **Error Response** (`500`): Failed to add source.
+- **Success Response** (`200`):
+  ```json
+  { "status": "success", "data": { ...ContentSource object... } }
+  ```
 
 ---
 
@@ -178,7 +181,10 @@ Updates a monitored content source. Only the fields provided are updated.
     "config": { "priority": 2 }
   }
   ```
-- **Success Response** (`200`): The updated `ContentSource` object.
+- **Success Response** (`200`):
+  ```json
+  { "status": "success", "data": { ...ContentSource object... } }
+  ```
 - **Error Response** (`400`): No fields provided to update.
 - **Error Response** (`404`): Source not found.
 
@@ -263,7 +269,10 @@ Manually **approve or reject** an item, overriding the LLM classification.
   - `is_technical: true` → sets `technical_score = 5`, `status = "queued"`
   - `is_technical: false` → sets `technical_score = 1`, `status = "skipped"`
   - The `classification_reason` is stored inside `source_metadata.classification_reason`
-- **Success Response** (`200`): The updated `ContentItem` object.
+- **Success Response** (`200`):
+  ```json
+  { "status": "success", "data": { ...ContentItem object... } }
+  ```
 - **Error Response** (`404`): Item not found.
 
 ---
@@ -505,3 +514,40 @@ Extracts the direct streamable video URL from a YouTube link.
   { "status": "success", "video_url": "https://..." }
   ```
 - **Error Response** (`500`): Could not extract the video URL.
+
+---
+
+## 5. Audiobook Router — `/audiobooks`
+
+---
+
+#### `GET /audiobooks/playlists`
+
+List all audio playlists. Returns playlists ordered by last updated (newest first). Does not include episodes.
+
+- **Query Parameters**:
+  - `status` (string): Filter by status (`draft`, `published`, `archived`)
+  - `playlist_type` (string): Filter by type (`series`, `collection`)
+  - `limit` (int): Max results (default: `50`, max: `100`)
+  - `offset` (int): Pagination offset (default: `0`)
+- **Response**: `{ "data": [ ... ], "total": 10 }`
+
+---
+
+#### `GET /audiobooks/playlists/{slug}`
+
+Get a single playlist by slug, including all ordered episodes.
+
+- **Path Parameter**: `slug` — Slug of the playlist
+- **Response**: `{ "data": { ...playlist object with episodes array... } }`
+- **Error Response** (`404`): Playlist not found.
+
+---
+
+#### `GET /audiobooks/episodes/{episode_id}`
+
+Get a single episode by UUID. Useful for deep-linking directly to a specific episode.
+
+- **Path Parameter**: `episode_id` — UUID of the episode
+- **Response**: `{ "data": { ...episode object... } }`
+- **Error Response** (`404`): Episode not found.

--- a/generate_audiobook.py
+++ b/generate_audiobook.py
@@ -33,9 +33,12 @@ def main():
     try:
         with open(args.input, "r", encoding="utf-8") as f:
             text = f.read()
+            if not text.strip():
+                print(f"❌ Error: File '{args.input}' is empty.")
+                raise SystemExit(1)
     except FileNotFoundError:
         print(f"❌ Error: File '{args.input}' not found.")
-        return
+        raise SystemExit(1)
 
     print("Initializing Audiobook Service...")
     service = AudiobookService()

--- a/generate_audiobook.py
+++ b/generate_audiobook.py
@@ -1,0 +1,59 @@
+"""Generate a single audiobook from a text file (legacy CLI).
+
+For the full playlist-aware curation pipeline, use curate_audiobooks.py
+instead.
+
+Usage:
+    python generate_audiobook.py sample_bitcoin.txt
+    python generate_audiobook.py sample_bitcoin.txt --skip-llm
+"""
+import argparse
+
+from app.services.audiobook_service import AudiobookService
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate an audiobook from a text file."
+    )
+    parser.add_argument("input", help="path to a .txt transcript")
+    parser.add_argument(
+        "--skip-llm",
+        action="store_true",
+        help="Bypass the OpenAI rewrite step",
+    )
+    parser.add_argument(
+        "--diarize",
+        action="store_true",
+        help="Enable dynamic multi-speaker diarization",
+    )
+    args = parser.parse_args()
+
+    print(f"Reading file: {args.input}...")
+    try:
+        with open(args.input, "r", encoding="utf-8") as f:
+            text = f.read()
+    except FileNotFoundError:
+        print(f"❌ Error: File '{args.input}' not found.")
+        return
+
+    print("Initializing Audiobook Service...")
+    service = AudiobookService()
+
+    print(
+        "Generating audiobook... "
+        "(This may take a minute depending on TTS and LLM speeds)"
+    )
+    result = service.generate_from_text(text=text, skip_llm=args.skip_llm, diarize=args.diarize)
+
+    if result:
+        print(f"\n✅ Success!")
+        print(f"Title: {result['title']}")
+        print(f"Audio File Saved To: {result['audio_url']}")
+        print(f"Duration: {result['duration_seconds']}s")
+    else:
+        print("\n❌ Failed to generate audiobook.")
+
+
+if __name__ == "__main__":
+    main()

--- a/routes/audiobooks.py
+++ b/routes/audiobooks.py
@@ -5,7 +5,8 @@ Endpoints:
     GET /audiobooks/playlists/{slug}            — single playlist + episodes
     GET /audiobooks/episodes/{episode_id}       — single episode
 """
-from typing import Optional
+from typing import Optional, Literal
+import uuid
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -27,11 +28,11 @@ def _service() -> PlaylistService:
 
 @router.get("/playlists")
 def list_playlists(
-    status: Optional[str] = Query(
+    status: Optional[Literal["draft", "published", "archived"]] = Query(
         None,
         description="Filter by status: draft | published | archived",
     ),
-    playlist_type: Optional[str] = Query(
+    playlist_type: Optional[Literal["series", "collection"]] = Query(
         None,
         description="Filter by type: series | collection",
     ),
@@ -92,13 +93,13 @@ def get_playlist(slug: str):
 # ─────────────────────────────────────────────────────────────────────────────
 
 @router.get("/episodes/{episode_id}")
-def get_episode(episode_id: str):
+def get_episode(episode_id: uuid.UUID):
     """Get a single episode by UUID.
 
     Useful for deep-linking directly to a specific episode.
     """
     try:
-        episode = _service().get_episode_by_id(episode_id)
+        episode = _service().get_episode_by_id(str(episode_id))
         if not episode:
             raise HTTPException(
                 status_code=404,

--- a/routes/audiobooks.py
+++ b/routes/audiobooks.py
@@ -1,0 +1,112 @@
+"""Read-only REST API for audiobook playlists and episodes.
+
+Endpoints:
+    GET /audiobooks/playlists                   — list all playlists
+    GET /audiobooks/playlists/{slug}            — single playlist + episodes
+    GET /audiobooks/episodes/{episode_id}       — single episode
+"""
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.logging import get_logger
+from app.services.audiobook.playlist_service import PlaylistService
+
+
+logger = get_logger()
+router = APIRouter(tags=["Audiobooks"])
+
+
+def _service() -> PlaylistService:
+    return PlaylistService()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /audiobooks/playlists
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/playlists")
+def list_playlists(
+    status: Optional[str] = Query(
+        None,
+        description="Filter by status: draft | published | archived",
+    ),
+    playlist_type: Optional[str] = Query(
+        None,
+        description="Filter by type: series | collection",
+    ),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """List all audio playlists.
+
+    Returns playlists ordered by last updated (newest first).
+    Does NOT include episodes — use /playlists/{slug} for that.
+    """
+    try:
+        service = _service()
+        playlists = service.list_playlists(
+            status=status,
+            playlist_type=playlist_type,
+            limit=limit,
+            offset=offset,
+        )
+        total = service.count_playlists(
+            status=status,
+            playlist_type=playlist_type,
+        )
+        return {"data": playlists, "total": total}
+    except Exception as e:
+        logger.error(f"Failed to list playlists: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /audiobooks/playlists/{slug}
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/playlists/{slug}")
+def get_playlist(slug: str):
+    """Get a single playlist by slug, including all ordered episodes.
+
+    Episodes are sorted by sequence_number ascending.
+    Episodes with status != 'completed' will have audio_url = null.
+    """
+    try:
+        playlist = _service().get_playlist_by_slug(slug)
+        if not playlist:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Playlist '{slug}' not found.",
+            )
+        return {"data": playlist}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get playlist '{slug}': {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GET /audiobooks/episodes/{episode_id}
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/episodes/{episode_id}")
+def get_episode(episode_id: str):
+    """Get a single episode by UUID.
+
+    Useful for deep-linking directly to a specific episode.
+    """
+    try:
+        episode = _service().get_episode_by_id(episode_id)
+        if not episode:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Episode '{episode_id}' not found.",
+            )
+        return {"data": episode}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get episode '{episode_id}': {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/scripts/migrate_schema.py
+++ b/scripts/migrate_schema.py
@@ -136,6 +136,7 @@ def run_migration(dry_run=False):
                 FROM deduped_source_rows
                 ON CONFLICT (slug) DO UPDATE SET
                     name = EXCLUDED.name,
+                    source_type = EXCLUDED.source_type,
                     base_url = EXCLUDED.base_url,
                     config = EXCLUDED.config,
                     is_active = EXCLUDED.is_active,
@@ -192,7 +193,10 @@ def run_migration(dry_run=False):
                 manual_source_id = conn.execute(text("""
                     INSERT INTO content_sources (name, slug, source_type, is_active)
                     VALUES ('Manual Imports', 'manual-imports', 'manual', true)
-                    ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+                    ON CONFLICT (slug) DO UPDATE SET 
+                        name = EXCLUDED.name,
+                        source_type = EXCLUDED.source_type,
+                        is_active = EXCLUDED.is_active
                     RETURNING id;
                 """)).scalar()
 
@@ -214,6 +218,7 @@ def run_migration(dry_run=False):
                         last_id = batch[-1].id
 
                 migrated_transcripts_count = 0
+                ci_versions = {}
                 for t in iter_transcripts():
                     t_id = t.id
                     raw = t.raw_text
@@ -244,11 +249,19 @@ def run_migration(dry_run=False):
                         """), {"s_id": manual_source_id, "ext_id": ext_id, "title": t.title or 'Unknown', "url": db_url}).first()
                         content_item_id = row[0]
 
+                    version = ci_versions.get(content_item_id, 0) + 1
+                    ci_versions[content_item_id] = version
+                    
+                    if version > 1:
+                        conn.execute(text("""
+                            UPDATE transcripts SET is_current = false WHERE content_item_id = :ci_id
+                        """), {"ci_id": content_item_id})
+
                     conn.execute(text("""
                         INSERT INTO transcripts (id, content_item_id, is_current, version, raw_text, corrected_text, created_at)
-                        VALUES (:t_id, :ci_id, true, 1, :raw, :corr, :created_at)
+                        VALUES (:t_id, :ci_id, true, :version, :raw, :corr, :created_at)
                         ON CONFLICT (id) DO NOTHING
-                    """), {"t_id": t_id, "ci_id": content_item_id, "raw": raw, "corr": corrected, "created_at": t.created_at})
+                    """), {"t_id": t_id, "ci_id": content_item_id, "version": version, "raw": raw, "corr": corrected, "created_at": t.created_at})
                     migrated_transcripts_count += 1
                     
                     if summary:

--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ from routes.curator import router as curator_router
 from routes.ingestion import router as ingestion_router
 from routes.media import router as media_router
 from routes.transcription import router as transcription_router
-from routes.translation import router as translation_router
+from routes.audiobooks import router as audiobooks_router
 
 # Ensure our app logger is configured to output to stdout
 configure_logger(log_level=logging.INFO)
@@ -52,4 +52,4 @@ app.include_router(transcription_router, prefix="/transcription")
 app.include_router(curator_router, prefix="/curator")
 app.include_router(media_router, prefix="/media")
 app.include_router(ingestion_router, prefix="/ingestion")
-app.include_router(translation_router, prefix="/translation")
+app.include_router(audiobooks_router, prefix="/audiobooks")

--- a/upload_existing.py
+++ b/upload_existing.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from pathlib import Path
+
+# Add the app to Python path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from app.database import get_session
+from app.models import AudioEpisode, AudioPlaylist
+from app.services.audiobook.storage import upload_to_supabase
+from app.logging import get_logger
+
+logger = get_logger()
+
+def main():
+    if not os.environ.get("SUPABASE_URL") or not os.environ.get("SUPABASE_KEY"):
+        logger.error("Please set SUPABASE_URL and SUPABASE_KEY environment variables.")
+        return
+
+    with get_session() as session:
+        # Find all episodes that have local paths (not remote URLs)
+        episodes = session.query(AudioEpisode).filter(
+            AudioEpisode.audio_url.isnot(None),
+            ~AudioEpisode.audio_url.like('http://%'),
+            ~AudioEpisode.audio_url.like('https://%'),
+        ).all()
+        
+        if not episodes:
+            logger.info("No episodes with local audio paths found.")
+            return
+            
+        logger.info(f"Found {len(episodes)} episodes to migrate to Supabase.")
+        
+        for ep in episodes:
+            local_path = Path(ep.audio_url)
+            if not local_path.exists():
+                logger.warning(f"File not found: {local_path}. Skipping.")
+                continue
+                
+            playlist = session.query(AudioPlaylist).filter_by(id=ep.playlist_id).first()
+            playlist_title = playlist.title if playlist else "Unknown"
+            
+            safe_ep_title = "".join(c if c.isalnum() or c in " _-" else "" for c in ep.title).replace(" ", "_")
+            ext = local_path.suffix
+            destination_path = f"{playlist_title}/{safe_ep_title}{ext}"
+            
+            logger.info(f"Uploading {ep.title} to {destination_path}...")
+            public_url = upload_to_supabase(local_path, "audiobooks", destination_path)
+            
+            if public_url:
+                ep.audio_url = public_url
+                session.commit()
+                logger.info(f"Updated DB for {ep.title} -> {public_url}")
+            else:
+                logger.error(f"Failed to upload {ep.title}")
+
+if __name__ == "__main__":
+    main()

--- a/upload_existing.py
+++ b/upload_existing.py
@@ -40,9 +40,10 @@ def main():
             playlist = session.query(AudioPlaylist).filter_by(id=ep.playlist_id).first()
             playlist_title = playlist.title if playlist else "Unknown"
             
+            safe_playlist_title = "".join(c if c.isalnum() or c in " _-" else "" for c in playlist_title).replace(" ", "_")
             safe_ep_title = "".join(c if c.isalnum() or c in " _-" else "" for c in ep.title).replace(" ", "_")
             ext = local_path.suffix
-            destination_path = f"{playlist_title}/{safe_ep_title}{ext}"
+            destination_path = f"{safe_playlist_title}/{safe_ep_title}{ext}"
             
             logger.info(f"Uploading {ep.title} to {destination_path}...")
             public_url = upload_to_supabase(local_path, "audiobooks", destination_path)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a read‑only `/audiobooks` API for playlists and episodes, plus new CLIs and docs for running the audiobook pipeline. Improves rewrite, stitching, storage safety, text cleaning, and migration/DB robustness.

- **New Features**
  - Read‑only API at `/audiobooks`: `GET /playlists`, `GET /playlists/{slug}`, `GET /episodes/{episode_id}`.
  - CLIs: `curate_audiobooks.py` (playlist curation), `generate_audiobook.py` (single file), `upload_existing.py` (migrate local audio to Supabase).
  - Docs: API guide updated with an Audiobooks section and responses; server registers the new router.

- **Refactors**
  - LLM rewrite now chunks long inputs and merges chapters; pipeline logs full exceptions.
  - Audio stitching normalizes frame rate/channels/sample width; improved timestamp/speaker regex (avoids false positives like “Chapter:”).
  - Supabase uploads sanitize/encode path segments; playlist/episode updates restricted to allowed fields.
  - Ingestion defaults invalid frontmatter `type` to `single_article` with a warning; `.gitignore` includes `input/audiobooks/`.
  - Migration/DB: updates `source_type`, versions transcripts with `is_current` rollover, ensures manual source creation, and adds safe fallback slugs for speakers.

<sup>Written for commit 18a7a22b39d62b8bb1375554438b3db800852819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/genesis-kb/transcription_engine/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

