### PR TITLE
feat: update database models, migration scripts, and index management

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -234,10 +234,12 @@ class ContentItem(Base):
             else None,
         }
         if include_source and self.source:
+            source_config = self.source.config or {}
             d["content_source"] = {
                 "name": self.source.name,
                 "source_type": self.source.source_type,
                 "slug": self.source.slug,
+                "category": source_config.get("category", ""),
             }
         else:
             d["content_source"] = None
@@ -350,6 +352,9 @@ class Transcript(Base):
     )
 
     __table_args__ = (
+        UniqueConstraint(
+            "content_item_id", "version", name="uq_transcripts_content_item_version"
+        ),
         Index(
             "idx_single_active_transcript",
             "content_item_id",

--- a/app/services/channel_scanner.py
+++ b/app/services/channel_scanner.py
@@ -38,30 +38,19 @@ class ChannelScanner:
             logger.info("No active channels to scan.")
             return {"items_discovered": 0, "errors": []}
 
-        run = self._db.create_pipeline_run(
-            started_at=datetime.now(timezone.utc)
-        )
-        run_id = run["id"] if run else None
-
         total_discovered = 0
         errors = []
 
         for channel in channels:
             try:
-                count = self._scan_channel(channel)
-                total_discovered += count
+                result = self.scan_channel_by_id(channel["id"])
+                total_discovered += result["items_discovered"]
+                if result.get("errors"):
+                    errors.extend(result["errors"])
             except Exception as e:
                 error_msg = f"Error scanning {channel['name']}: {e}"
                 logger.error(error_msg)
                 errors.append(error_msg)
-
-        if run_id:
-            status = 'failed' if errors else 'success'
-            self._db.complete_pipeline_run(
-                run_id,
-                status=status,
-                completed_at=datetime.now(timezone.utc),
-            )
 
         logger.info(f"Scan complete: {total_discovered} new items discovered.")
         return {"items_discovered": total_discovered, "errors": errors}
@@ -155,7 +144,7 @@ class ChannelScanner:
             self._db.update_source_last_scanned(channel_db_id)
             return 0
 
-        existing = self._db.get_existing_item_external_ids(video_ids)
+        existing = self._db.get_existing_item_external_ids(channel_db_id, video_ids)
         new_ids = [vid for vid in video_ids if vid not in existing]
 
         if not new_ids:

--- a/app/services/content_classifier.py
+++ b/app/services/content_classifier.py
@@ -60,7 +60,7 @@ class ContentClassifier:
             try:
                 result = self._classify_item(item)
                 classified += 1
-                if result["is_technical"]:
+                if result["is_technical"] and result["confidence"] >= self.confidence_threshold:
                     approved += 1
                 else:
                     rejected += 1
@@ -88,7 +88,7 @@ class ContentClassifier:
             "errors": errors,
         }
 
-    def classify_video_by_id(self, item_db_id: str) -> dict:
+    def classify_item_by_id(self, item_db_id: str) -> dict:
         """Classify a single item by its database UUID."""
         item = self._db.get_item_by_id(item_db_id)
         if not item:
@@ -106,7 +106,7 @@ class ContentClassifier:
         Returns:
             Classification result dict.
         """
-        source_metadata = item.get("source_metadata", {})
+        source_metadata = item.get("source_metadata") or {}
         duration = source_metadata.get("duration") or 0
         
         # Skip items outside duration range
@@ -130,8 +130,7 @@ class ContentClassifier:
         # Get channel info from joined data
         source_info = item.get("content_source") or {}
         channel_name = source_info.get("name", "")
-        # The category isn't normally passed in include_source dict anymore, just default to slug
-        channel_category = source_info.get("slug", "unknown")
+        channel_category = source_info.get("category", source_info.get("slug", "unknown"))
 
         title = item.get("title", "")
         description = item.get("description", "")
@@ -166,7 +165,7 @@ class ContentClassifier:
     def _save_classification(self, item: dict, result: dict, status: str):
         """Persist classification result to the database."""
         item_id = item["id"]
-        source_metadata = item.get("source_metadata", {})
+        source_metadata = item.get("source_metadata") or {}
         source_metadata["classification_reason"] = result["reason"]
         source_metadata["classification_confidence"] = result["confidence"]
         

--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -37,93 +37,132 @@ class DatabaseService:
     def save_from_transcript_object(self, transcript) -> Optional[dict]:
         if not self.is_available:
             return None
-        try:
-            with get_session() as session:
-                source = transcript.source
-                media_url = source.source_file
-                video_id = None
-                if "v=" in media_url:
-                    video_id = media_url.split("v=")[-1].split("&")[0]
-                elif "youtu.be/" in media_url:
-                    video_id = media_url.split("youtu.be/")[-1].split("?")[0]
+            
+        from sqlalchemy.exc import IntegrityError
+        import time
+        
+        for attempt in range(3):
+            try:
+                with get_session() as session:
+                    source = transcript.source
+                    raw_media_url = source.source_file
+                    if isinstance(raw_media_url, str):
+                        raw_media_url = raw_media_url.strip()
+                    media_url = raw_media_url or None
 
-                content_item = None
-                if video_id:
-                    content_item = session.query(ContentItem).filter_by(external_id=video_id).first()
-                
-                if not content_item:
-                    # Find or create manual source
-                    manual_source = session.query(ContentSource).filter_by(slug='manual-imports').first()
-                    if not manual_source:
-                        manual_source = ContentSource(
-                            name='Manual Imports',
-                            slug='manual-imports',
-                            source_type='manual',
-                            is_active=True
-                        )
-                        session.add(manual_source)
-                        session.flush()
+                    video_id = None
+                    media_url_for_parsing = media_url or ""
+                    if "v=" in media_url_for_parsing:
+                        video_id = media_url_for_parsing.split("v=")[-1].split("&")[0]
+                    elif "youtu.be/" in media_url_for_parsing:
+                        video_id = media_url_for_parsing.split("youtu.be/")[-1].split("?")[0]
 
-                    ext_id = video_id if video_id else f"manual-{int(datetime.now().timestamp())}"
+                    import uuid
                     
-                    content_item = session.query(ContentItem).filter_by(external_id=ext_id).first()
-                    if not content_item:
-                        content_item = ContentItem(
-                            source_id=manual_source.id,
-                            external_id=ext_id,
-                            title=source.title or 'Unknown',
-                            content_type='video',
-                            url=media_url,
-                            status='transcribed'
-                        )
-                        session.add(content_item)
-                        session.flush()
-                else:
-                    content_item.status = 'transcribed'
-
-                # Add transcript
-                t = Transcript(
-                    content_item_id=content_item.id,
-                    is_current=True,
-                    version=1,
-                    raw_text=transcript.outputs.get("raw", ""),
-                    corrected_text=transcript.outputs.get("corrected_text", "")
-                )
-                session.add(t)
-                session.flush()
-                
-                # Add summary
-                summary_text = transcript.summary if hasattr(transcript, "summary") else None
-                if summary_text:
-                    s = Summary(
-                        transcript_id=t.id,
-                        summary_type='tldr',
-                        content=summary_text
-                    )
-                    session.add(s)
-
-                # Add speakers
-                if source.speakers:
-                    import re
-                    for spk_name in source.speakers:
-                        spk_slug = re.sub(r"[^\w\s-]", "", spk_name.lower().strip())
-                        spk_slug = re.sub(r"[-\s]+", "-", spk_slug).strip("-") or "unknown"
-                        spk = session.query(Speaker).filter_by(slug=spk_slug).first()
-                        if not spk:
-                            spk = Speaker(name=spk_name, slug=spk_slug)
-                            session.add(spk)
-                            session.flush()
+                    content_source = None
+                    if hasattr(source, "loc") and source.loc:
+                        content_source = session.query(ContentSource).filter_by(slug=source.loc).first()
                         
-                        cis = session.query(ContentItemSpeaker).filter_by(content_item_id=content_item.id, speaker_id=spk.id).first()
-                        if not cis:
-                            cis = ContentItemSpeaker(content_item_id=content_item.id, speaker_id=spk.id, role='speaker')
-                            session.add(cis)
+                    content_item = None
+                    if video_id:
+                        query = session.query(ContentItem).filter_by(external_id=video_id)
+                        if content_source:
+                            query = query.filter_by(source_id=content_source.id)
+                        content_item = query.first()
+                    
+                    if not content_item:
+                        if content_source:
+                            target_source_id = content_source.id
+                        else:
+                            # Find or create manual source
+                            manual_source = session.query(ContentSource).filter_by(slug='manual-imports').first()
+                            if not manual_source:
+                                manual_source = ContentSource(
+                                    name='Manual Imports',
+                                    slug='manual-imports',
+                                    source_type='manual',
+                                    is_active=True
+                                )
+                                session.add(manual_source)
+                                session.flush()
+                            target_source_id = manual_source.id
 
-                session.commit()
-                return t.to_dict()
-        except Exception as e:
-            logger.error(f"Failed to save transcript object: {e}")
-            return None
+                        ext_id = video_id if video_id else f"manual-{uuid.uuid4().hex[:12]}"
+                        
+                        content_item = session.query(ContentItem).filter_by(source_id=target_source_id, external_id=ext_id).first()
+                        if not content_item:
+                            content_item = ContentItem(
+                                source_id=target_source_id,
+                                external_id=ext_id,
+                                title=source.title or 'Unknown',
+                                content_type='video',
+                                url=media_url,
+                                status='transcribed'
+                            )
+                            session.add(content_item)
+                            session.flush()
+                    else:
+                        content_item.status = 'transcribed'
+
+                    # Lock existing transcripts to prevent race condition
+                    existing_transcripts = session.query(Transcript).filter_by(content_item_id=content_item.id).with_for_update().all()
+                    
+                    next_version = 1
+                    for existing_t in existing_transcripts:
+                        if existing_t.version >= next_version:
+                            next_version = existing_t.version + 1
+                        if existing_t.is_current:
+                            existing_t.is_current = False
+
+                    # Add transcript
+                    t = Transcript(
+                        content_item_id=content_item.id,
+                        is_current=True,
+                        version=next_version,
+                        raw_text=transcript.outputs.get("raw", ""),
+                        corrected_text=transcript.outputs.get("corrected_text") or None
+                    )
+                    session.add(t)
+                    session.flush()
+                    
+                    # Add summary
+                    summary_text = transcript.summary if hasattr(transcript, "summary") else None
+                    if summary_text:
+                        s = Summary(
+                            transcript_id=t.id,
+                            summary_type='tldr',
+                            content=summary_text
+                        )
+                        session.add(s)
+
+                    # Add speakers
+                    if source.speakers:
+                        from app.utils import slugify
+                        for spk_name in source.speakers:
+                            spk_slug = slugify(spk_name)
+                            spk = session.query(Speaker).filter_by(slug=spk_slug).first()
+                            if not spk:
+                                spk = Speaker(name=spk_name, slug=spk_slug)
+                                session.add(spk)
+                                session.flush()
+                            
+                            cis = session.query(ContentItemSpeaker).filter_by(content_item_id=content_item.id, speaker_id=spk.id).first()
+                            if not cis:
+                                cis = ContentItemSpeaker(content_item_id=content_item.id, speaker_id=spk.id, role='speaker')
+                                session.add(cis)
+
+                    session.commit()
+                    return t.to_dict()
+            except IntegrityError:
+                if attempt < 2:
+                    time.sleep(0.1 * (attempt + 1))
+                    continue
+                logger.error("Failed to save transcript object due to IntegrityError after retries.")
+                return None
+            except Exception as e:
+                logger.error(f"Failed to save transcript object: {e}")
+                return None
+        return None
 
     def get_all_transcripts(self, limit: int = 100, offset: int = 0) -> list:
         if not self.is_available:
@@ -207,6 +246,15 @@ class DatabaseService:
                 if source_type:
                     query = query.filter_by(source_type=source_type)
                 objs = query.all()
+                
+                # Sort deterministically by priority (from config, descending) then name (ascending)
+                def get_priority(obj):
+                    try:
+                        return int(obj.config.get("priority", 0)) if isinstance(obj.config, dict) else 0
+                    except (ValueError, TypeError):
+                        return 0
+
+                objs.sort(key=lambda x: (-get_priority(x), x.name or ""))
                 return [obj.to_dict() for obj in objs]
         except Exception as e:
             logger.error(f"Failed to get active sources: {e}")
@@ -306,7 +354,7 @@ class DatabaseService:
                 )
                 if obj:
                     # using config jsonb to store last_scanned_at
-                    config = obj.config or {}
+                    config = dict(obj.config or {})
                     config["last_scanned_at"] = datetime.now(timezone.utc).isoformat()
                     obj.config = config
                     session.commit()
@@ -334,13 +382,14 @@ class DatabaseService:
             )
             return None
 
-    def get_existing_item_external_ids(self, external_ids: list[str]) -> set:
+    def get_existing_item_external_ids(self, source_id: str, external_ids: list[str]) -> set:
         if not self.is_available or not external_ids:
             return set()
         try:
             with get_session() as session:
                 rows = (
                     session.query(ContentItem.external_id)
+                    .filter(ContentItem.source_id == source_id)
                     .filter(ContentItem.external_id.in_(external_ids))
                     .all()
                 )
@@ -370,7 +419,7 @@ class DatabaseService:
     def list_content_items(
         self,
         status: Optional[str] = None,
-        technical_score: Optional[int] = None,
+        is_technical: Optional[bool] = None,
         source_id: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
@@ -386,9 +435,13 @@ class DatabaseService:
                 )
                 if status:
                     query = query.filter(ContentItem.status == status)
-                if technical_score is not None:
+                if is_technical is True:
                     query = query.filter(
-                        ContentItem.technical_score >= technical_score
+                        ContentItem.technical_score >= 4
+                    )
+                elif is_technical is False:
+                    query = query.filter(
+                        ContentItem.technical_score < 4
                     )
                 if source_id:
                     query = query.filter(ContentItem.source_id == source_id)

--- a/app/services/ingestion_service.py
+++ b/app/services/ingestion_service.py
@@ -101,12 +101,13 @@ class IngestionService:
         Args:
             item: Row from content_items table with joined source data.
         """
-        url = item.get("url")
-        if not url:
-            url = f"https://www.youtube.com/watch?v={item['external_id']}"
-
         source_info = item.get("content_source") or {}
         source_slug = source_info.get("slug", "misc")
+        source_type = source_info.get("source_type", "")
+
+        url = item.get("url")
+        if not url and source_type == "youtube":
+            url = f"https://www.youtube.com/watch?v={item['external_id']}"
 
         if not url:
             raise ValueError(
@@ -143,7 +144,7 @@ class IngestionService:
         # Update item status
         self._db.update_content_item(
             item["id"],
-            {"status": "transcribed"},
+            {"status": "in_queue"},
         )
 
         logger.info(f"Queued for transcription: {item.get('title', item['external_id'])}")

--- a/docs/local-run-and-queue.md
+++ b/docs/local-run-and-queue.md
@@ -1,80 +1,124 @@
-# Local Run And Queue Guide
+# Local Run & Queue Guide
 
-This runbook documents the exact flow to run the project locally, initialize the database, and queue 10 YouTube videos.
+A step-by-step guide to run the project locally, initialize the database, and queue YouTube videos for transcription.
 
-## 1. Install dependencies
+---
+
+## Prerequisites
+
+- Python 3.10+
+- A running PostgreSQL database (e.g. [Supabase](https://supabase.com))
+- A Google / YouTube API key
+
+---
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/<your-username>/transcription_engine.git
+cd transcription_engine
+```
+
+---
+
+## 2. Install dependencies
 
 ```bash
 python -m venv venv
-source venv/bin/activate
+source venv/bin/activate        # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
-/home/parth/Cloned_repos/transcription_engine/venv/bin/python -m uvicorn server:app --host 0.0.0.0 --port 8000
 
-## 2. Configure environment
+---
+
+## 3. Configure environment
 
 ```bash
 cp env.example .env
 ```
 
-Set at least these values in `.env`:
-
-- `DATABASE_URL`
-- `GOOGLE_API_KEY`
-- `YOUTUBE_API_KEY`
-
-Example (Supabase pooler):
+Open `.env` and set at minimum:
 
 ```env
-DATABASE_URL=postgresql://<user>:<password>@<pooler-host>:5432/postgres?sslmode=require
+DATABASE_URL=postgresql://<user>:<password>@<host>:5432/postgres?sslmode=require
+GOOGLE_API_KEY=your_google_api_key
+YOUTUBE_API_KEY=your_youtube_api_key
 ```
 
-## 3. Create database tables
+> **Tip:** If you are using the Supabase connection pooler, use the pooler hostname and include `sslmode=require`.
 
-The project does not auto-create tables on startup. Run this once:
+---
+
+## 4. Initialize the database
+
+The project does **not** auto-create tables on startup. Run this once after setting up your `.env`:
 
 ```bash
 python -c "from dotenv import load_dotenv; load_dotenv(); from app.database import init_db; print(init_db())"
 ```
 
-Expected result: `True`
+Expected output: `True`
 
-## 4. Start API server
+---
+
+## 5. Start the API server
 
 ```bash
 python -m uvicorn server:app --host 0.0.0.0 --port 8000
 ```
 
-## 5. Queue 10 YouTube videos
+The API will be available at `http://localhost:8000`.
 
-Use this shell snippet from a second terminal:
+---
+
+## 6. Queue YouTube videos
+
+Open a **second terminal** (with the virtual environment activated) and run:
 
 ```bash
-home/parth/Cloned_repos/transcription_engine/venv/bin/python -m uvicorn server:app --host 0.0.0.0 --port 8000
+curl -X POST http://localhost:8000/transcription/add_to_queue/ \
+  -F "source=https://www.youtube.com/watch?v=<VIDEO_ID>"
 ```
 
-## 6. Start processing queue
+Repeat for each video you want to queue. You can script this to queue multiple videos at once:
+
+```bash
+VIDEO_IDS=("id1" "id2" "id3")
+for id in "${VIDEO_IDS[@]}"; do
+  curl -X POST http://localhost:8000/transcription/add_to_queue/ \
+    -F "source=https://www.youtube.com/watch?v=${id}"
+done
+```
+
+---
+
+## 7. Start processing the queue
 
 ```bash
 curl -X POST http://localhost:8000/transcription/start/
 ```
 
-Note: This endpoint is `POST`. Opening it in the browser (`GET`) returns `{"detail":"Method Not Allowed"}`.
+> **Note:** This endpoint only accepts `POST`. A browser `GET` request will return `{"detail": "Method Not Allowed"}`.
 
-## 7. Verify status and saved data
+---
+
+## 8. Verify status and saved data
 
 ```bash
+# Check the current queue
 curl http://localhost:8000/transcription/queue/
+
+# List saved transcripts
 curl http://localhost:8000/transcription/db/transcripts/
 ```
 
+---
+
 ## Troubleshooting
 
-- `No module named uvicorn`
-  - Run: `pip install -r requirements.txt`
-- `ImportError: cannot import name 'genai' from 'google'`
-  - Ensure `google-genai` is installed from `requirements.txt`.
-- `DATABASE_URL not set`
-  - Ensure `.env` exists and load it in one-off commands with `load_dotenv()`.
-- `Network is unreachable` to Supabase on direct host
-  - Use Supabase pooler connection string and include `sslmode=require`.
+| Error | Fix |
+|-------|-----|
+| `No module named uvicorn` | Run `pip install -r requirements.txt` inside your virtual environment |
+| `ImportError: cannot import name 'genai' from 'google'` | Ensure `google-genai` is listed in `requirements.txt` and reinstall |
+| `DATABASE_URL not set` | Ensure `.env` exists and variables are exported; one-off commands need `load_dotenv()` |
+| `Network is unreachable` (Supabase) | Use the Supabase **pooler** connection string and add `sslmode=require` |

--- a/routes/ingestion.py
+++ b/routes/ingestion.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.logging import get_logger
 from app.services.database_service import get_database_service
@@ -16,7 +16,7 @@ class SourceCreate(BaseModel):
     slug: str
     source_type: str = "youtube"
     base_url: Optional[str] = None
-    config: dict = {}
+    config: dict = Field(default_factory=dict)
     is_active: bool = True
 
 
@@ -115,6 +115,8 @@ async def update_source(source_id: str, updates: SourceUpdate):
     }
     if not update_data:
         raise HTTPException(status_code=400, detail="No fields to update.")
+        
+
     result = db.update_source(source_id, update_data)
     if result is None:
         raise HTTPException(status_code=404, detail="Source not found.")
@@ -154,7 +156,7 @@ async def classify_item(item_id: str):
 
     try:
         classifier = ContentClassifier()
-        result = classifier.classify_video_by_id(item_id)
+        result = classifier.classify_item_by_id(item_id)
         return {"status": "success", **result}
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -174,13 +176,9 @@ async def list_items(
     """List discovered items with optional filters."""
     db = _get_db()
     
-    # We still allow filtering by technical_score conceptually using the bool flag, 
-    # but the DB now uses technical_score. is_technical=True means technical_score >= 4
-    technical_score = 4 if is_technical else None
-    
     data = db.list_content_items(
         status=status,
-        technical_score=technical_score,
+        is_technical=is_technical,
         source_id=source_id,
         limit=limit,
         offset=offset,
@@ -205,7 +203,7 @@ async def override_item(item_id: str, override: ItemOverride):
     # Update source_metadata to include reason
     item = db.get_item_by_id(item_id)
     if item:
-        meta = item.get("source_metadata", {})
+        meta = item.get("source_metadata") or {}
         meta["classification_reason"] = override.classification_reason or "Manual override"
         meta["classification_confidence"] = 1.0
         updates["source_metadata"] = meta

--- a/scripts/add_indexes.py
+++ b/scripts/add_indexes.py
@@ -26,55 +26,64 @@ def add_indexes():
 
     index_sqls = [
         # content_sources
-        "CREATE INDEX IF NOT EXISTS idx_sources_type ON content_sources(source_type);",
-        "CREATE INDEX IF NOT EXISTS idx_sources_active ON content_sources(is_active) WHERE is_active = true;",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sources_type ON content_sources(source_type);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sources_active ON content_sources(is_active) WHERE is_active = true;",
         
         # content_items
-        "CREATE INDEX IF NOT EXISTS idx_items_source ON content_items(source_id);",
-        "CREATE INDEX IF NOT EXISTS idx_items_event ON content_items(event_id);",
-        "CREATE INDEX IF NOT EXISTS idx_items_status ON content_items(status);",
-        "CREATE INDEX IF NOT EXISTS idx_items_type ON content_items(content_type);",
-        "CREATE INDEX IF NOT EXISTS idx_items_published ON content_items(published_at DESC);",
-        "CREATE INDEX IF NOT EXISTS idx_items_technical ON content_items(technical_score) WHERE technical_score >= 4;",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_source ON content_items(source_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_event ON content_items(event_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_status ON content_items(status);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_type ON content_items(content_type);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_published ON content_items(published_at DESC);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_technical ON content_items(technical_score) WHERE technical_score >= 4;",
         
         # content_items FTS (Titles & Descriptions)
         """
-        CREATE INDEX IF NOT EXISTS idx_items_fts 
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_fts 
         ON content_items USING GIN(to_tsvector('english', COALESCE(title, '') || ' ' || COALESCE(description, '')));
         """,
         
         # content_item_speakers
-        "CREATE INDEX IF NOT EXISTS idx_cis_speaker ON content_item_speakers(speaker_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cis_speaker ON content_item_speakers(speaker_id);",
         
         # taxonomies
-        "CREATE INDEX IF NOT EXISTS idx_taxonomies_parent ON taxonomies(parent_id);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_taxonomies_parent ON taxonomies(parent_id);",
         
         # transcripts FTS (GIN index on tsvector) - Partial index only for active transcripts
         """
-        CREATE INDEX IF NOT EXISTS idx_transcripts_fts 
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transcripts_fts 
         ON transcripts USING GIN(to_tsvector('english', COALESCE(corrected_text, raw_text, '')))
         WHERE is_current = true;
         """,
         
         # summaries
-        "CREATE INDEX IF NOT EXISTS idx_summaries_type ON summaries(summary_type);",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_summaries_type ON summaries(summary_type);",
         
         # summaries FTS (GIN index on tsvector)
         """
-        CREATE INDEX IF NOT EXISTS idx_summaries_fts 
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_summaries_fts 
         ON summaries USING GIN(to_tsvector('english', COALESCE(content, '')));
         """
     ]
 
-    with engine.connect() as conn:
-        with conn.begin():
-            # Postgres GIN indexes require the pg_trgm extension for some advanced text operations,
-            # though to_tsvector doesn't strictly need it, it's good to have.
-            conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pg_trgm";'))
-            
-            for sql in index_sqls:
-                logger.info(f"Executing: {sql.strip().split(chr(10))[0]}...")
-                conn.execute(text(sql))
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        # Postgres GIN indexes require the pg_trgm extension for some advanced text operations,
+        # though to_tsvector doesn't strictly need it, it's good to have.
+        add_pg_trgm_extension = os.getenv("ADD_PG_TRGM_EXTENSION", "true").lower() in ("1", "true", "yes", "on")
+        if add_pg_trgm_extension:
+            try:
+                conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pg_trgm";'))
+            except Exception as e:
+                logger.warning(
+                    f'Could not create optional PostgreSQL extension "pg_trgm": {e}. '
+                    "Continuing with index creation."
+                )
+        else:
+            logger.info('Skipping optional PostgreSQL extension creation for "pg_trgm".')
+        
+        for sql in index_sqls:
+            logger.info(f"Executing: {sql.strip().split(chr(10))[0]}...")
+            conn.execute(text(sql))
 
     logger.info("All indexes created successfully!")
 

--- a/scripts/migrate_schema.py
+++ b/scripts/migrate_schema.py
@@ -5,8 +5,7 @@ import json
 import logging
 import argparse
 from datetime import datetime, timezone
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import text
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -79,18 +78,53 @@ def run_migration(dry_run=False):
             # 4. Migrate Data
             logger.info("Migrating data from old_youtube_channels -> content_sources...")
             migrate_sources_sql = """
+                WITH source_rows AS (
+                    SELECT
+                        id,
+                        channel_name,
+                        channel_url,
+                        channel_id,
+                        category,
+                        priority,
+                        is_active,
+                        created_at,
+                        LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g')) AS base_slug
+                    FROM old_youtube_channels
+                ),
+                deduped_source_rows AS (
+                    SELECT
+                        id,
+                        channel_name,
+                        channel_url,
+                        channel_id,
+                        category,
+                        priority,
+                        is_active,
+                        created_at,
+                        CASE
+                            WHEN COUNT(*) OVER (PARTITION BY base_slug) > 1 THEN base_slug || '-' || id
+                            ELSE base_slug
+                        END AS slug
+                    FROM source_rows
+                )
                 INSERT INTO content_sources (id, name, slug, source_type, base_url, config, is_active, last_run_status, created_at)
-                SELECT 
-                    id, 
-                    channel_name, 
-                    LOWER(REGEXP_REPLACE(channel_name, '[^a-zA-Z0-9]+', '-', 'g')), 
-                    'youtube', 
-                    channel_url, 
-                    jsonb_build_object('yt_channel_id', channel_id, 'category', category, 'priority', priority), 
-                    is_active, 
-                    NULL, 
+                SELECT
+                    id,
+                    channel_name,
+                    slug,
+                    'youtube',
+                    channel_url,
+                    jsonb_build_object('yt_channel_id', channel_id, 'category', category, 'priority', priority),
+                    is_active,
+                    NULL,
                     created_at
-                FROM old_youtube_channels;
+                FROM deduped_source_rows
+                ON CONFLICT (slug) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    base_url = EXCLUDED.base_url,
+                    config = EXCLUDED.config,
+                    is_active = EXCLUDED.is_active,
+                    created_at = EXCLUDED.created_at;
             """
             if not dry_run:
                 res = conn.execute(text(migrate_sources_sql))
@@ -136,14 +170,29 @@ def run_migration(dry_run=False):
                 manual_source_id = conn.execute(text("""
                     INSERT INTO content_sources (name, slug, source_type, is_active)
                     VALUES ('Manual Imports', 'manual-imports', 'manual', true)
+                    ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
                     RETURNING id;
                 """)).scalar()
 
-                transcripts = conn.execute(text("SELECT * FROM old_transcripts")).fetchall()
-                logger.info(f"Processing {len(transcripts)} old transcripts...")
+                total_transcripts = conn.execute(text("SELECT COUNT(*) FROM old_transcripts")).scalar()
+                logger.info(f"Processing {total_transcripts} old transcripts in batches...")
                 
+                def iter_transcripts():
+                    last_id = None
+                    batch_size = 100
+                    while True:
+                        if last_id is None:
+                            batch = conn.execute(text("SELECT * FROM old_transcripts ORDER BY id LIMIT :limit"), {"limit": batch_size}).fetchall()
+                        else:
+                            batch = conn.execute(text("SELECT * FROM old_transcripts WHERE id > :last_id ORDER BY id LIMIT :limit"), {"limit": batch_size, "last_id": last_id}).fetchall()
+                        if not batch:
+                            break
+                        for row in batch:
+                            yield row
+                        last_id = batch[-1].id
+
                 migrated_transcripts_count = 0
-                for t in transcripts:
+                for t in iter_transcripts():
                     t_id = t.id
                     raw = t.raw_text
                     corrected = t.corrected_text
@@ -164,17 +213,19 @@ def run_migration(dry_run=False):
                     
                     if not content_item_id:
                         ext_id = video_id if video_id else f"manual-{t_id}"
+                        db_url = t.media_url if t.media_url else None
                         row = conn.execute(text("""
                             INSERT INTO content_items (source_id, external_id, title, content_type, url, status)
                             VALUES (:s_id, :ext_id, :title, 'video', :url, 'transcribed')
                             ON CONFLICT (source_id, external_id) DO UPDATE SET title = EXCLUDED.title
                             RETURNING id;
-                        """), {"s_id": manual_source_id, "ext_id": ext_id, "title": t.title or 'Unknown', "url": t.media_url}).first()
+                        """), {"s_id": manual_source_id, "ext_id": ext_id, "title": t.title or 'Unknown', "url": db_url}).first()
                         content_item_id = row[0]
 
                     conn.execute(text("""
                         INSERT INTO transcripts (id, content_item_id, is_current, version, raw_text, corrected_text, created_at)
                         VALUES (:t_id, :ci_id, true, 1, :raw, :corr, :created_at)
+                        ON CONFLICT (id) DO NOTHING
                     """), {"t_id": t_id, "ci_id": content_item_id, "raw": raw, "corr": corrected, "created_at": t.created_at})
                     migrated_transcripts_count += 1
                     
@@ -218,6 +269,22 @@ def run_migration(dry_run=False):
             if not dry_run:
                 res = conn.execute(text(migrate_runs_sql))
                 logger.info(f"Migrated {res.rowcount} pipeline runs.")
+                
+                # Link sources to their latest pipeline runs (must run after pipeline_runs are populated)
+                update_last_run_sql = """
+                    UPDATE content_sources cs
+                    SET last_run_id = pr.id,
+                        last_run_status = pr.status
+                    FROM (
+                        SELECT id, source_id, status,
+                               ROW_NUMBER() OVER(PARTITION BY source_id ORDER BY started_at DESC) as rn
+                        FROM pipeline_runs
+                        WHERE source_id IS NOT NULL
+                    ) pr
+                    WHERE cs.id = pr.source_id AND pr.rn = 1;
+                """
+                conn.execute(text(update_last_run_sql))
+                logger.info("Linked content_sources to their latest pipeline runs.")
             else:
                 logger.info(f"DRY RUN: {migrate_runs_sql}")
 


### PR DESCRIPTION
- database_service: add IntegrityError retry loop, scope external_id lookups by source_id, replace technical_score filter with is_technical boolean, add priority sorting, safe config dict copy
- channel_scanner: per-channel pipeline runs, source_id in get_existing_item_external_ids
- content_classifier: confidence threshold, null-safe source_metadata, category from config
- ingestion_service: source-type aware URL building, in_queue status fix
- routes/ingestion: Field(default_factory=dict), classify_item_by_id rename
- scripts/migrate_schema: slug dedup, batch processing, idempotent inserts, last_run linkage
- scripts/add_indexes: updated indexes
- models: add category to content_source dict, UniqueConstraint on transcripts
- docs/local-run-and-queue: improved runbook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the DB schema and ingestion/classification flows for safer writes, better filtering, and faster queries. Adds unique transcript versioning, source-scoped lookups, `is_technical` filtering, concurrent index creation, and an idempotent migration with a clearer local runbook.

- New Features
  - Unique transcript versioning with locking and retry on `IntegrityError`; older versions are unmarked as current.
  - Source-aware behavior: external ID checks scoped by `source_id`; YouTube URL fallback only when `source_type` is `youtube`; item status set to `in_queue`.
  - Classification and APIs: confidence threshold for approvals; channel `category` included in `content_source`; null-safe `source_metadata`; `classify_item_by_id` rename; safer Pydantic `config`; active sources sorted by `config.priority`; `is_technical` filter replaces numeric score; per-channel scanning and scoped existing checks.

- Migration
  - Idempotent data migration with slug de-duplication, batched transcript processing, ON CONFLICT inserts, and linking `content_sources` to their latest `pipeline_runs`.
  - Indexes created CONCURRENTLY with autocommit; optional `pg_trgm` enabled via `ADD_PG_TRGM_EXTENSION`.

<sup>Written for commit 09323986991159bcfde9ff798cd6b9f7a8c75547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/genesis-kb/transcription_engine/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

